### PR TITLE
Batch 1: low-risk docs/packaging/API fixes (#25 #27 #28 #31 #37 #41 #46 #53 #54)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to BVID-FE!
 
 ## Reporting Bugs
 
-Open an [issue](https://github.com/elhajjar1/BVID-FE/issues) with:
+Open an [issue](https://github.com/ranipdx-glitch/BVID-FE/issues) with:
 - Python version and OS
 - Steps to reproduce the problem
 - Expected vs actual behavior
@@ -20,7 +20,7 @@ Open an issue describing:
 ## Development Setup
 
 ```bash
-git clone https://github.com/elhajjar1/BVID-FE.git
+git clone https://github.com/ranipdx-glitch/BVID-FE.git
 cd BVID-FE
 pip install -e ".[all]"
 pytest tests/ -v

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
-[![Tests](https://img.shields.io/badge/tests-309%20passing-brightgreen.svg)](https://github.com/elhajjar1/BVID-FE/actions)
+[![Tests](https://github.com/ranipdx-glitch/BVID-FE/actions/workflows/tests.yml/badge.svg)](https://github.com/ranipdx-glitch/BVID-FE/actions/workflows/tests.yml)
 
 A Python library for predicting residual strength and stiffness of fiber-reinforced composite laminates containing Barely Visible Impact Damage (BVID).
 
@@ -88,13 +88,11 @@ print(result.summary())
 ### Inspection-driven path (C-scan import)
 
 ```python
-import json
 from bvidfe.damage.io import load_cscan_json
 from bvidfe.analysis import AnalysisConfig, BvidAnalysis
 from bvidfe.core.geometry import PanelGeometry
 
-with open("scan.json") as f:
-    damage_state = load_cscan_json(json.load(f))
+damage_state = load_cscan_json("scan.json")
 
 cfg = AnalysisConfig(
     material="AS4/3501-6",
@@ -115,9 +113,9 @@ print(f"Knockdown: {result.knockdown:.3f}")
 from bvidfe.sweep.parametric_sweep import sweep_energies
 
 results_df = sweep_energies(
+    cfg,
     energies_J=[10, 20, 30, 40, 50],
-    base_config=cfg,
-    output_csv="knockdown_vs_energy.csv",
+    csv_path="knockdown_vs_energy.csv",
 )
 ```
 
@@ -197,7 +195,7 @@ If you use BVID-FE in your research, please cite:
   year      = {2026},
   version   = {0.1.0-alpha},
   publisher = {GitHub},
-  url       = {https://github.com/elhajjar1/BVID-FE},
+  url       = {https://github.com/ranipdx-glitch/BVID-FE},
   note      = {University of Wisconsin-Milwaukee}
 }
 ```

--- a/docs/python_api.md
+++ b/docs/python_api.md
@@ -172,7 +172,7 @@ my_mat = OrthotropicMaterial(
     E11=150e3, E22=9e3, nu12=0.32,
     G12=4.5e3, G13=4.5e3, G23=3.2e3,
     Xt=2200, Xc=1500, Yt=65, Yc=180, S12=85, S23=55,
-    G_Ic=0.27, G_IIc=0.85, rho=1.58e-6,
+    G_Ic=0.27, G_IIc=0.85, rho=1.58e-6,  # rho in kg/mm^3 (1.58 g/cm^3)
     # Optional impact/calibration constants (defaults for CFRP):
     olsson_alpha=0.8,     # DPA scaling
     soutis_k_s=2.5,       # Soutis CAI constant

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,20 @@ dependencies = [
 [project.optional-dependencies]
 dev = ["pytest>=7,<9", "ruff>=0.5,<1", "black>=24,<26"]
 
+[project.urls]
+Homepage = "https://github.com/ranipdx-glitch/BVID-FE"
+Repository = "https://github.com/ranipdx-glitch/BVID-FE"
+Issues = "https://github.com/ranipdx-glitch/BVID-FE/issues"
+Changelog = "https://github.com/ranipdx-glitch/BVID-FE/blob/main/CHANGELOG.md"
+
 [project.scripts]
 bvidfe = "bvidfe.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.package-data]
+bvidfe = ["py.typed"]
 
 [tool.black]
 line-length = 100

--- a/src/bvidfe/__init__.py
+++ b/src/bvidfe/__init__.py
@@ -1,3 +1,36 @@
-"""BVID-FE — Barely Visible Impact Damage analysis for composite laminates."""
+"""BVID-FE — Barely Visible Impact Damage analysis for composite laminates.
+
+The most commonly used public types are re-exported here so callers can
+``from bvidfe import AnalysisConfig, BvidAnalysis, ...`` without learning
+the internal module layout. The deep import paths keep working.
+"""
 
 __version__ = "0.2.0.dev0"
+
+from bvidfe.analysis import (
+    AnalysisConfig,
+    AnalysisResults,
+    BvidAnalysis,
+    MeshParams,
+)
+from bvidfe.core.geometry import ImpactorGeometry, PanelGeometry
+from bvidfe.core.material import MATERIAL_LIBRARY, OrthotropicMaterial
+from bvidfe.damage.io import load_cscan_json
+from bvidfe.damage.state import DamageState, DelaminationEllipse
+from bvidfe.impact.mapping import ImpactEvent
+
+__all__ = [
+    "AnalysisConfig",
+    "AnalysisResults",
+    "BvidAnalysis",
+    "MeshParams",
+    "ImpactEvent",
+    "ImpactorGeometry",
+    "PanelGeometry",
+    "MATERIAL_LIBRARY",
+    "OrthotropicMaterial",
+    "DamageState",
+    "DelaminationEllipse",
+    "load_cscan_json",
+    "__version__",
+]

--- a/src/bvidfe/cli.py
+++ b/src/bvidfe/cli.py
@@ -63,6 +63,7 @@ def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="bvidfe",
         description="BVID-FE: Barely Visible Impact Damage residual-strength analysis.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     p.add_argument(
         "--version",
@@ -91,8 +92,17 @@ def _build_parser() -> argparse.ArgumentParser:
         type=_parse_panel,
         help="Panel dimensions as LxY in millimeters, e.g. 150x100",
     )
-    p.add_argument("--loading", choices=["compression", "tension"])
-    p.add_argument("--tier", default="empirical", choices=["empirical", "semi_analytical", "fe3d"])
+    p.add_argument(
+        "--loading",
+        choices=["compression", "tension"],
+        help="Load case: compression-after-impact or tension-after-impact",
+    )
+    p.add_argument(
+        "--tier",
+        default="empirical",
+        choices=["empirical", "semi_analytical", "fe3d"],
+        help="Analysis fidelity tier",
+    )
     p.add_argument(
         "--energy",
         type=_positive_float,

--- a/src/bvidfe/core/__init__.py
+++ b/src/bvidfe/core/__init__.py
@@ -1,0 +1,13 @@
+"""Core composite-mechanics types (geometry, material, laminate)."""
+
+from bvidfe.core.geometry import ImpactorGeometry, PanelGeometry
+from bvidfe.core.laminate import Laminate
+from bvidfe.core.material import MATERIAL_LIBRARY, OrthotropicMaterial
+
+__all__ = [
+    "ImpactorGeometry",
+    "PanelGeometry",
+    "Laminate",
+    "MATERIAL_LIBRARY",
+    "OrthotropicMaterial",
+]

--- a/src/bvidfe/core/laminate.py
+++ b/src/bvidfe/core/laminate.py
@@ -141,7 +141,7 @@ class Laminate:
     """
 
     material: OrthotropicMaterial
-    layup_deg: list
+    layup_deg: list[float]
     ply_thickness_mm: float
 
     # Computed on post-init; stored as private attributes.

--- a/src/bvidfe/core/material.py
+++ b/src/bvidfe/core/material.py
@@ -14,7 +14,7 @@ class OrthotropicMaterial:
     impact-mapping calibration constants.
 
     Units: moduli and strengths in MPa (N/mm^2), fracture toughness in N/mm,
-    density in t/mm^3 (consistent units for a SI-mm-N-s system).
+    density in kg/mm^3 (e.g. 1.58e-6 for CFRP, matching 1.58 g/cm^3).
 
     Through-thickness strengths (Zt, Zc) and the 1-3 shear strength (S13)
     are optional. For unidirectional CFRP plies under the transverse-isotropy
@@ -84,6 +84,16 @@ class OrthotropicMaterial:
                 raise ValueError(f"{k} must be > 0 if provided (got {v})")
         if not -1.0 < self.nu12 < 0.5:
             raise ValueError(f"nu12 out of physical range (got {self.nu12})")
+        # rho is kg/mm^3; realistic engineering materials span ~[1e-7, 1e-5]
+        # (0.1 .. 10 g/cm^3). A value outside this range almost always means
+        # the user followed the old (wrong) "t/mm^3" docstring and is 1000x
+        # off, which silently corrupts the impact-mapping mass ratio.
+        if not 1e-7 <= self.rho <= 1e-5:
+            raise ValueError(
+                f"rho={self.rho} kg/mm^3 is outside the realistic range "
+                f"[1e-7, 1e-5] (0.1-10 g/cm^3). Note rho is kg/mm^3, "
+                f"e.g. 1.58e-6 for CFRP."
+            )
 
     @property
     def nu21(self) -> float:

--- a/src/bvidfe/damage/__init__.py
+++ b/src/bvidfe/damage/__init__.py
@@ -1,0 +1,10 @@
+"""Damage-state types and C-scan I/O."""
+
+from bvidfe.damage.io import load_cscan_json
+from bvidfe.damage.state import DamageState, DelaminationEllipse
+
+__all__ = [
+    "DamageState",
+    "DelaminationEllipse",
+    "load_cscan_json",
+]

--- a/src/bvidfe/impact/__init__.py
+++ b/src/bvidfe/impact/__init__.py
@@ -1,0 +1,8 @@
+"""Impact event modelling and impact-to-damage mapping."""
+
+from bvidfe.impact.mapping import ImpactEvent, impact_to_damage
+
+__all__ = [
+    "ImpactEvent",
+    "impact_to_damage",
+]

--- a/src/bvidfe/impact/mapping.py
+++ b/src/bvidfe/impact/mapping.py
@@ -85,11 +85,8 @@ def _dynamic_amplification_factor(
     than the plate (m_ratio < 1 — the small-mass regime where the Olsson
     quasi-static threshold can underpredict damage by 30%+).
 
-    Note on units: ``OrthotropicMaterial.rho`` is specified in kg/mm^3
-    (e.g. 1.57e-6 for CFRP, matching 1.57 g/cm^3). The docstring in
-    ``core/material.py`` says "t/mm^3" for a hypothetical SI-mm-N-s mass
-    unit, but the actual numerical values follow the kg/mm^3 convention;
-    we treat them as kg/mm^3 to compute a physically meaningful m_ratio.
+    ``OrthotropicMaterial.rho`` is in kg/mm^3 (e.g. 1.57e-6 for CFRP,
+    matching 1.57 g/cm^3); the m_ratio below is therefore in consistent kg.
     """
     rho_kg_per_mm3 = lam.material.rho
     m_plate_eff_kg = rho_kg_per_mm3 * panel.Lx_mm * panel.Ly_mm * lam.thickness_mm


### PR DESCRIPTION
## Summary

Batch 1 of the issue cleanup — low-risk docs, packaging, and additive API ergonomics. No behavioural change to the analysis numerics.

(Batch 2 — #4 #26 #32 #38 #43 #50 #51 — was split out into a separate PR for finer-grained review.)

| Issue | Fix |
|---|---|
| #25 | Re-export public types from `bvidfe`, `bvidfe.core`, `bvidfe.damage`, `bvidfe.impact` (additive — deep imports still work) |
| #27 | README C-scan example passed a dict to `load_cscan_json`; it takes a path |
| #28 | Replace stale static `tests-309 passing` badge with a CI-driven workflow-status badge; fix broken `elhajjar1` repo URLs in README/CONTRIBUTING |
| #31 | `OrthotropicMaterial.rho` documented as `t/mm³` but values are `kg/mm³`; correct docstrings (material.py, mapping.py, python_api.md) + add a realistic-range `__post_init__` guard |
| #37 | README parametric-sweep example used non-existent kwargs (`base_config=`, `output_csv=`) |
| #41 | `Laminate.layup_deg` bare `list` → `list[float]` |
| #46 | CLI `--help` now shows defaults (`ArgumentDefaultsHelpFormatter` + help text on `--tier`/`--loading`) |
| #53 | Ship PEP 561 `py.typed` marker + `package-data` so downstream type-checkers honour hints |
| #54 | Add `[project.urls]` (Homepage / Repository / Issues / Changelog) to `pyproject.toml` |

### Judgement calls

- **#28 CHANGELOG**: the "309 passing" line lives in a *dated historical changelog entry* — rewriting it would falsify the log. The CI-driven badge removes the manual numeric claim from the README, which is the actual fix.
- **#41**: the `ply_thicknesses_mm` property referenced in the issue doesn't exist (multi-thickness is the still-open #5); only the applicable bare-annotation part is fixed.

## Test plan

- [x] `pytest -q` → 297 passed, 1 xfailed (unchanged from main).
- [x] `ruff check` + `black --check` clean.
- [x] `from bvidfe import AnalysisConfig, BvidAnalysis, ImpactEvent, PanelGeometry, DamageState, load_cscan_json, ...` works.
- [x] `py.typed` present in the installed package.
- [x] `OrthotropicMaterial(..., rho=1.58e-9)` now raises (old wrong-unit value).
- [x] `bvidfe --help` shows `--tier ... (default: empirical)`.

https://claude.ai/code/session_01PqfGE89GSnJLETCUxsCdc2