### PR TITLE
Batch 2: docs + structured warnings + deterministic sweep (#4 #26 #32 #38 #43 #50 #51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ bvidfe --material IM7/8552 \
        --energy 30
 ```
 
+All lengths are in **millimetres**. `--panel` is `<Lx>x<Ly>` (in-plane
+dimensions, x then y, literal `x` separator, no spaces — e.g. `150x100`
+is Lx = 150 mm, Ly = 100 mm). `--thickness` is the per-ply thickness in
+mm, `--layup` is a comma-separated list of ply angles in degrees, and
+`--energy` is the impact energy in joules.
+
 ### Python API — impact-driven path
 
 ```python

--- a/src/bvidfe/analysis/bvid.py
+++ b/src/bvidfe/analysis/bvid.py
@@ -75,6 +75,7 @@ class BvidAnalysis:
         damage = self._resolve_damage(lam)
         sigma_0 = _pristine_strength(lam, self.config.loading)
         notes: list[str] = []
+        warnings_tags: list[str] = []
 
         if self.config.tier == "empirical":
             sigma = self._empirical(lam, damage, sigma_0)
@@ -99,6 +100,8 @@ class BvidAnalysis:
                     self.config, damage, lam, sigma_0
                 )
                 notes.extend(buckling_notes)
+                if buckling_notes:
+                    warnings_tags.append("fe3d_buckling_unconverged")
                 sigma_fpf = _fe3d_cai_first_ply_failure(self.config, damage, lam, sigma_0)
                 buckling_plausible = sigma_buckling >= 0.05 * sigma_0
                 if not buckling_plausible and not buckling_notes:
@@ -112,11 +115,26 @@ class BvidAnalysis:
                         f"5% of pristine ({sigma_0:.1f} MPa); discarded as a "
                         "numerical artefact and used first-ply-failure instead."
                     )
+                    warnings_tags.append("fe3d_buckling_artefact_dropped")
                 sigma = min(sigma_buckling, sigma_fpf) if buckling_plausible else sigma_fpf
                 buckling_eigs = [lambda_crit] if lambda_crit > 0 else None
+                fpf_governs = not buckling_plausible
             else:
                 sigma = fe3d_tai(self.config, damage, lam, sigma_0)
                 buckling_eigs = None
+                fpf_governs = True
+            # The FPF / TAI BC builders (compression_bcs / tension_bcs) do
+            # not yet honour cfg.panel.boundary — only the buckling path
+            # does. When the reported residual comes from FPF/TAI and a
+            # non-default boundary was requested, surface that it had no
+            # effect rather than letting it look silently applied (#32).
+            if fpf_governs and self.config.panel.boundary != "simply_supported":
+                notes.append(
+                    f"fe3d FPF/TAI: panel.boundary="
+                    f"{self.config.panel.boundary!r} is not yet applied to "
+                    f"the FPF/TAI BC set; the residual is unaffected by it."
+                )
+                warnings_tags.append("fe3d_boundary_not_applied_to_fpf_tai")
             critical_interface = None
             field_results = None
         else:
@@ -134,6 +152,7 @@ class BvidAnalysis:
             critical_sublaminate=critical_interface,
             field_results=field_results,
             notes=notes,
+            warnings=warnings_tags,
         )
 
     def _resolve_damage(self, lam: Laminate) -> DamageState:

--- a/src/bvidfe/analysis/config.py
+++ b/src/bvidfe/analysis/config.py
@@ -13,7 +13,32 @@ from bvidfe.impact.mapping import ImpactEvent
 
 @dataclass
 class MeshParams:
-    """Mesh resolution parameters for the 3D FE tier."""
+    """Mesh resolution parameters for the ``tier="fe3d"`` solve.
+
+    Parameters
+    ----------
+    elements_per_ply : int
+        Number of hex elements stacked through the thickness of each ply
+        (dimensionless count, ``>= 1``). Total through-thickness elements
+        ``nz = n_plies * elements_per_ply``. Default ``1`` (one element
+        per ply) is adequate for first-ply-failure screening; increase
+        for smoother through-thickness stress gradients at higher cost.
+    in_plane_size_mm : float
+        Target in-plane element edge length in millimetres (``> 0``). The
+        mesh uses ``nx = ceil(Lx_mm / in_plane_size_mm)`` and
+        ``ny = ceil(Ly_mm / in_plane_size_mm)`` elements in x and y, so
+        smaller values resolve the stress concentration around the damage
+        footprint more finely at quadratically higher element count and
+        memory. Default ``5.0`` mm. On Streamlit Cloud (1 GB RAM) keep
+        this ``>= 5`` mm.
+    cohesive_zone_factor : float
+        Reserved (``> 0``, default ``1.0``). Intended as a multiplier on
+        the cohesive-zone characteristic length once true cohesive
+        surfaces land (see README "Limitations"); **currently validated
+        but not consumed** by ``build_fe_mesh`` — the present fe3d tier
+        uses a component-wise stiffness-reduction model, not cohesive
+        elements. Leave at the default.
+    """
 
     elements_per_ply: int = 1
     in_plane_size_mm: float = 5.0

--- a/src/bvidfe/analysis/results.py
+++ b/src/bvidfe/analysis/results.py
@@ -12,7 +12,46 @@ from bvidfe.damage.state import DamageState
 
 @dataclass
 class FieldResults:
-    """3D FE tier field outputs. Populated only when tier='fe3d'."""
+    """Per-mesh field outputs reserved for the 3D FE tier.
+
+    .. note::
+       **Currently always ``None``.** ``BvidAnalysis.run()`` does not yet
+       populate ``AnalysisResults.field_results`` for any tier (the fe3d
+       tier returns scalar residual strength + buckling eigenvalues only).
+       This dataclass documents the *intended* contract for a future
+       field-output release; downstream code should treat
+       ``result.field_results`` as optional and handle ``None``.
+
+    Attributes
+    ----------
+    displacement : np.ndarray
+        Nodal displacement, shape ``(n_nodes, 3)``, float64, units mm,
+        in the global (x, y, z) coordinate system, original (undeformed)
+        node ordering.
+    stress_global : np.ndarray
+        Per-element stress in the global frame, shape
+        ``(n_elements, 6)``, units MPa, Voigt order
+        ``[σxx, σyy, σzz, σyz, σxz, σxy]``.
+    strain_global : np.ndarray
+        Per-element strain in the global frame, shape
+        ``(n_elements, 6)``, dimensionless, same Voigt order as
+        ``stress_global``.
+    stress_local : np.ndarray
+        Per-element stress rotated into each ply's material (fibre) axes,
+        shape ``(n_elements, 6)``, units MPa, Voigt order
+        ``[σ11, σ22, σ33, σ23, σ13, σ12]``.
+    failure_index : np.ndarray
+        Per-element maximum failure index, shape ``(n_elements,)``,
+        dimensionless (≥ 1.0 indicates predicted first-ply failure).
+    buckling_mode_shape : np.ndarray, optional
+        First buckling eigenvector as nodal displacement, shape
+        ``(n_nodes, 3)``, normalised (dimensionless). ``None`` when no
+        buckling solve ran or it did not converge.
+    cohesive_damage : np.ndarray, optional
+        Per-interface-element scalar cohesive damage variable in
+        ``[0, 1]`` (0 = intact, 1 = fully separated). ``None`` until
+        true cohesive surfaces land (see README "Limitations").
+    """
 
     displacement: np.ndarray
     stress_global: np.ndarray
@@ -61,6 +100,25 @@ class AnalysisResults:
     critical_sublaminate: Optional[int] = None
     field_results: Optional[FieldResults] = None
     notes: List[str] = field(default_factory=list)
+    #: Machine-readable diagnostic tags, distinct from the human-readable
+    #: ``notes``. Lets a script disambiguate an overloaded ``knockdown``
+    #: (e.g. ``knockdown == 1.0`` from "pristine-equivalent" vs "fe3d
+    #: buckling eigensolve failed") without string-scraping ``notes``.
+    #: Populated tags (default ``[]``):
+    #:
+    #: - ``"fe3d_buckling_unconverged"`` — the fe3d buckling eigensolve
+    #:   reported its own failure; residual is from first-ply failure.
+    #: - ``"fe3d_buckling_artefact_dropped"`` — buckling solved but the
+    #:   result was below 5% of pristine and was discarded as a numerical
+    #:   artefact; residual is from first-ply failure.
+    #: - ``"fe3d_boundary_not_applied_to_fpf_tai"`` — a non-default
+    #:   ``panel.boundary`` was requested but the FPF/TAI BC set does not
+    #:   yet honour it (only the buckling path does).
+    #:
+    #: The ``impactor_mass_ratio_below_unity`` / ``dpa_panel_area_cap_clipped``
+    #: regimes currently surface only via Python ``UserWarning`` + ``notes``;
+    #: structured tags for them are future work.
+    warnings: List[str] = field(default_factory=list)
 
     def summary(self) -> str:
         lines = [
@@ -77,6 +135,10 @@ class AnalysisResults:
             lines.append("  notes:")
             for note in self.notes:
                 lines.append(f"    - {note}")
+        if self.warnings:
+            lines.append("  warnings:")
+            for w in self.warnings:
+                lines.append(f"    - {w}")
         return "\n".join(lines)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -104,5 +166,6 @@ class AnalysisResults:
             "critical_sublaminate": self.critical_sublaminate,
             "config_snapshot": self.config_snapshot,
             "notes": list(self.notes),
+            "warnings": list(self.warnings),
         }
         return out

--- a/src/bvidfe/sweep/parametric_sweep.py
+++ b/src/bvidfe/sweep/parametric_sweep.py
@@ -87,6 +87,28 @@ def _try_run_one(cfg: AnalysisConfig, on_error: str, label: str) -> dict:
         return row
 
 
+# Fixed result schema. The swept independent variable goes first; `error`
+# is always present (NaN/empty on success) so downstream `df["error"]`
+# never KeyErrors and column order is identical across runs (#38).
+_RESULT_COLS = (
+    "knockdown",
+    "residual_MPa",
+    "pristine_MPa",
+    "dpa_mm2",
+    "dent_mm",
+    "n_delaminations",
+    "tier_used",
+    "error",
+)
+
+
+def _finalize(rows: List[dict], swept_col: str) -> pd.DataFrame:
+    """Build the DataFrame with a deterministic column order regardless of
+    how many iterations failed: ``[swept_col, *_RESULT_COLS]`` with
+    ``error`` always present (#38)."""
+    return pd.DataFrame(rows).reindex(columns=[swept_col, *_RESULT_COLS])
+
+
 def _write_csv(df: pd.DataFrame, csv_path: Optional[Path]) -> None:
     if csv_path is not None:
         df.to_csv(Path(csv_path), index=False)
@@ -120,7 +142,7 @@ def sweep_energies(
         row["energy_J"] = float(E)
         rows.append(row)
         _emit_progress(progress_callback, i + 1, n)
-    df = pd.DataFrame(rows)
+    df = _finalize(rows, "energy_J")
     _write_csv(df, Path(csv_path) if csv_path else None)
     return df
 
@@ -143,7 +165,7 @@ def sweep_layups(
         row["layup"] = layup_str
         rows.append(row)
         _emit_progress(progress_callback, i + 1, n)
-    df = pd.DataFrame(rows)
+    df = _finalize(rows, "layup")
     _write_csv(df, Path(csv_path) if csv_path else None)
     return df
 
@@ -165,6 +187,6 @@ def sweep_thicknesses(
         row["ply_thickness_mm"] = float(t)
         rows.append(row)
         _emit_progress(progress_callback, i + 1, n)
-    df = pd.DataFrame(rows)
+    df = _finalize(rows, "ply_thickness_mm")
     _write_csv(df, Path(csv_path) if csv_path else None)
     return df

--- a/src/bvidfe/viz/plots_2d.py
+++ b/src/bvidfe/viz/plots_2d.py
@@ -151,7 +151,7 @@ def plot_knockdown_curve(
     color = COLORS.get(tier_label, COLORS["knockdown"])
     ax.plot(energies_J, knockdowns, "-o", color=color, label=tier_label or "knockdown")
     ax.set_xlabel("Impact energy [J]")
-    ax.set_ylabel("Strength retention (knockdown)")
+    ax.set_ylabel("Strength retention (knockdown) [-]")
     ax.set_ylim(0, 1.05)
     ax.grid(True, linestyle="--", alpha=0.3)
     if tier_label:
@@ -177,7 +177,7 @@ def plot_tier_comparison(
         color = COLORS.get(tier, None)
         ax.plot(energies_J, kd, "-o", color=color, label=tier)
     ax.set_xlabel("Impact energy [J]")
-    ax.set_ylabel("Strength retention (knockdown)")
+    ax.set_ylabel("Strength retention (knockdown) [-]")
     ax.set_ylim(0, 1.05)
     ax.grid(True, linestyle="--", alpha=0.3)
     ax.legend()

--- a/tests/sweep/test_sweep.py
+++ b/tests/sweep/test_sweep.py
@@ -160,3 +160,30 @@ def test_sweep_energies_rejects_unknown_on_error():
 
     with pytest.raises(ValueError, match="on_error must be one of"):
         sweep_energies(cfg, energies_J=[5], on_error="bogus")
+
+
+def test_sweep_column_schema_is_deterministic():
+    """Issue #38: column order is fixed (swept var first, `error` always
+    present) regardless of whether any iteration failed."""
+    expected_results = [
+        "knockdown",
+        "residual_MPa",
+        "pristine_MPa",
+        "dpa_mm2",
+        "dent_mm",
+        "n_delaminations",
+        "tier_used",
+        "error",
+    ]
+    cfg = _base_impact_cfg()
+
+    # All-success run with on_error='raise': `error` column still present.
+    df_e = sweep_energies(cfg, energies_J=[5, 10, 20])
+    assert list(df_e.columns) == ["energy_J", *expected_results]
+    assert df_e["error"].isna().all()
+
+    df_l = sweep_layups(cfg, layups=[[0, 90] * 8, [0, 45, -45, 90] * 4])
+    assert list(df_l.columns) == ["layup", *expected_results]
+
+    df_t = sweep_thicknesses(cfg, ply_thicknesses_mm=[0.125, 0.152])
+    assert list(df_t.columns) == ["ply_thickness_mm", *expected_results]


### PR DESCRIPTION
## Summary

Batch 2 of the issue cleanup — docs, an additive API field, and output determinism. No behavioural change to the analysis numerics. Independent of #58 (Batch 1); either can merge first.

| Issue | Fix |
|---|---|
| #4  | README: document CLI length units (mm) and `--panel Lx x Ly` format |
| #26 | Add structured `AnalysisResults.warnings` field (machine-readable tags) so an overloaded `knockdown == 1.0` is disambiguable without string-scraping `notes`; surfaced in `summary()` + `to_dict()` |
| #32 | Safety-net: tag + note when fe3d FPF/TAI runs with a non-default `panel.boundary` it doesn't honour |
| #38 | Deterministic sweep DataFrame/CSV schema (swept var first, `error` always present) + regression test |
| #43 | Add `[-]` to dimensionless knockdown axes (other plot axes already carry mm / J units) |
| #50 | Full `MeshParams` docstring; `cohesive_zone_factor` documented honestly as reserved / not-yet-consumed |
| #51 | Full `FieldResults` docstring (shapes/units/coord system) with an explicit note that it is currently always `None` |

### Judgement calls / honest scoping

- **#32 / #26**: the *full* #32 fix (threading `panel.boundary` into the FPF/TAI BC builders) changes physics results and belongs on the physics track. This PR ships only the additive safety-net (note + structured tag) so the limitation is no longer silent.
- **#43 / #50 / #51**: existing plot axes already carry SI-mm/J units; `cohesive_zone_factor` and `FieldResults` are documented as the *reserved* features they currently are rather than inventing semantics they don't have.

## Test plan

- [x] `pytest -q` → **298 passed, 1 xfailed** (+1 new sweep-schema regression test).
- [x] `ruff check` + `black --check` clean.
- [x] fe3d run with `boundary='clamped'` emits `fe3d_boundary_not_applied_to_fpf_tai` in `result.warnings`; `to_dict()`/`summary()` carry it.
- [x] Sweep columns deterministic with `error` always present (NaN on all-success).

https://claude.ai/code/session_01PqfGE89GSnJLETCUxsCdc2

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqfGE89GSnJLETCUxsCdc2)_