### PR TITLE
Pin foundational invariants (patch test, assembly summation, back-face growth, small-mass warning) + A-matrix conditioning guard

### DIFF
--- a/src/bvidfe/core/laminate.py
+++ b/src/bvidfe/core/laminate.py
@@ -272,7 +272,16 @@ class Laminate:
             Effective Poisson's ratio nu_xy (dimensionless).
         """
         h = self.thickness_mm
-        a = np.linalg.inv(self._A)  # 3x3 compliance (mm/N)
+        # Guard against a numerically singular A: np.linalg.inv returns
+        # NaN/Inf (no exception) when det(A) ~ 0, which then propagates
+        # silently into stress recovery as garbage. Fail loudly instead.
+        cond = float(np.linalg.cond(self._A))
+        if not np.isfinite(cond) or cond > 1e10:
+            raise ValueError(
+                f"Laminate A matrix is ill-conditioned (cond={cond:.2e}); "
+                f"check layup / ply_thickness_mm consistency."
+            )
+        a = np.linalg.solve(self._A, np.eye(3))  # 3x3 compliance (mm/N)
         # Normalise by thickness to get extensional compliance per unit modulus
         a_star = a / h  # 1/MPa
 
@@ -280,6 +289,15 @@ class Laminate:
         Ey = 1.0 / a_star[1, 1]
         Gxy = 1.0 / a_star[2, 2]
         nuxy = -a_star[0, 1] / a_star[0, 0]
+
+        for name, val in (("Ex", Ex), ("Ey", Ey), ("Gxy", Gxy)):
+            if not np.isfinite(val) or val <= 0.0:
+                raise ValueError(
+                    f"effective {name}={val} from an ill-conditioned laminate "
+                    f"A matrix; check layup / ply_thickness_mm consistency."
+                )
+        if not np.isfinite(nuxy):
+            raise ValueError(f"effective nuxy={nuxy} from an ill-conditioned laminate A matrix.")
 
         return Ex, Ey, Gxy, nuxy
 

--- a/tests/core/test_laminate.py
+++ b/tests/core/test_laminate.py
@@ -37,3 +37,27 @@ def test_D_eff_positive():
     m = MATERIAL_LIBRARY["IM7/8552"]
     lam = Laminate(material=m, layup_deg=[0, 45, -45, 90] * 4, ply_thickness_mm=0.152)
     assert lam.flexural_rigidity_Deff() > 0
+
+
+def test_effective_engineering_constants_valid_laminate_finite_positive():
+    """Issue #21 regression: the new ill-conditioning guard must NOT
+    false-trigger on a normal laminate."""
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    lam = Laminate(m, [0, 45, -45, 90] * 4, 0.152)
+    Ex, Ey, Gxy, nuxy = lam.effective_engineering_constants()
+    for v in (Ex, Ey, Gxy):
+        assert np.isfinite(v) and v > 0.0
+    assert np.isfinite(nuxy)
+
+
+def test_effective_engineering_constants_raises_on_singular_A():
+    """Issue #21: a numerically singular A must raise loudly instead of
+    silently returning NaN/Inf that corrupts downstream stress recovery."""
+    import pytest
+
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    lam = Laminate(m, [0, 45, -45, 90] * 4, 0.152)
+    # Corrupt the cached A to a (nearly) singular matrix.
+    lam._A = np.full((3, 3), 1e-14)
+    with pytest.raises(ValueError, match="ill-conditioned"):
+        lam.effective_engineering_constants()

--- a/tests/elements/test_hex8.py
+++ b/tests/elements/test_hex8.py
@@ -128,3 +128,77 @@ def test_degenerate_element_error_is_a_value_error():
     """Defensive code that catches generic ValueError must still see the new
     error class — we do not want to break existing exception handlers."""
     assert issubclass(DegenerateElementError, ValueError)
+
+
+def _distorted_hex_nodes():
+    """A non-affine, irregularly distorted 8-node hex (no two faces parallel).
+
+    The constant-strain patch test must hold for *any* admissible element
+    shape, not just the unit cube — that is the whole point of the test.
+    """
+    return np.array(
+        [
+            [0.00, 0.00, 0.00],
+            [1.10, 0.05, -0.05],
+            [1.20, 1.15, 0.10],
+            [0.08, 0.95, -0.10],
+            [-0.05, 0.05, 1.05],
+            [1.00, -0.05, 1.15],
+            [1.15, 1.05, 1.20],
+            [0.05, 1.10, 0.95],
+        ],
+        dtype=float,
+    )
+
+
+def _u_from_strain_field(node_coords, exx=0.0, eyy=0.0, ezz=0.0, gxy=0.0):
+    """Element DOF vector (24,) for a spatially constant strain field.
+
+    u_x = exx*x + gxy*y,  u_y = eyy*y,  u_z = ezz*z
+    => Voigt strain [exx, eyy, ezz, 0, 0, gxy] everywhere (gxy = engineering
+    shear 2*e_xy, matching the Hex8 B-matrix Voigt convention).
+    """
+    u = np.zeros(24)
+    for k, (x, y, z) in enumerate(node_coords):
+        u[3 * k + 0] = exx * x + gxy * y
+        u[3 * k + 1] = eyy * y
+        u[3 * k + 2] = ezz * z
+    return u
+
+
+@pytest.mark.parametrize(
+    "field,expected",
+    [
+        (dict(exx=1e-3), [1e-3, 0, 0, 0, 0, 0]),
+        (dict(eyy=2e-3), [0, 2e-3, 0, 0, 0, 0]),
+        (dict(ezz=-1.5e-3), [0, 0, -1.5e-3, 0, 0, 0]),
+        (dict(gxy=3e-3), [0, 0, 0, 0, 0, 3e-3]),
+    ],
+)
+def test_hex8_constant_strain_patch_test_unit_cube(field, expected):
+    """B @ u_const must reproduce the imposed Voigt strain at every Gauss point."""
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    elem = Hex8Element(_unit_cube_nodes(), m)
+    u = _u_from_strain_field(elem.node_coords, **field)
+    strains = elem.strain_at_gauss_points(u)  # (n_gp, 6)
+    for gp_strain in strains:
+        assert np.allclose(gp_strain, expected, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "field,expected",
+    [
+        (dict(exx=1e-3), [1e-3, 0, 0, 0, 0, 0]),
+        (dict(gxy=3e-3), [0, 0, 0, 0, 0, 3e-3]),
+    ],
+)
+def test_hex8_constant_strain_patch_test_distorted_element(field, expected):
+    """The patch test must also pass on an arbitrarily distorted element —
+    this is the property that guarantees correct stress recovery on real
+    (non-cubic) meshes."""
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    elem = Hex8Element(_distorted_hex_nodes(), m)
+    u = _u_from_strain_field(elem.node_coords, **field)
+    strains = elem.strain_at_gauss_points(u)
+    for gp_strain in strains:
+        assert np.allclose(gp_strain, expected, atol=1e-10)

--- a/tests/impact/test_mapping.py
+++ b/tests/impact/test_mapping.py
@@ -75,3 +75,19 @@ def test_impact_to_damage_clips_large_dpa():
     assert ds.projected_damage_area_mm2 <= 0.8 * A_panel * 1.02  # 2% slack for union
     # And we should have emitted at least one UserWarning
     assert any("exceeds 80%" in str(msg.message) for msg in w)
+
+
+def test_small_mass_emits_quasi_static_warning():
+    """Issue #17: a sub-unity impactor/plate mass ratio must emit the
+    Olsson quasi-static-validity UserWarning. Regressing the m_ratio < 1.0
+    guard (or its message) would silently hide a documented 30%+ under-
+    prediction in drop-tower / light-impactor simulations."""
+    lam = Laminate(MATERIAL_LIBRARY["IM7/8552"], [0] * 16, 0.2)
+    pan = PanelGeometry(500, 500)
+    ev = ImpactEvent(energy_J=20.0, impactor=ImpactorGeometry(), mass_kg=0.5)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        impact_to_damage(ev, lam, pan)
+    assert any("quasi-static" in str(m.message) and "mass" in str(m.message) for m in w), [
+        str(m.message) for m in w
+    ]

--- a/tests/impact/test_shape_templates.py
+++ b/tests/impact/test_shape_templates.py
@@ -43,3 +43,25 @@ def test_empty_when_single_ply():
 def test_empty_when_nonpositive_target():
     assert distribute_damage([0, 90, 0], 0.0, 0.3, 0.0) == []
     assert distribute_damage([0, 90, 0], -5.0, 0.3, 0.0) == []
+
+
+def test_back_face_growth_axiom():
+    """Issue #16: delaminations must grow toward the back face (the
+    experimentally observed BVID signature encoded by _relative_size).
+
+    Constant-angle layup -> aspect_ratio == 1 at every interface, so any
+    size difference is purely the back-face growth ramp. A regression that
+    flipped or zeroed the ramp slope would still pass the existing
+    DPA-conservation / aspect-ratio tests but fail this one.
+    """
+    ellipses = distribute_damage(
+        [0] * 6,
+        target_dpa_mm2=600.0,
+        dent_depth_mm=0.3,
+        fiber_break_radius_mm=0.0,
+        centroid_mm=(75.0, 50.0),
+    )
+    ellipses.sort(key=lambda e: e.interface_index)
+    # Model ratio is (0.3 + 0.7*1) / (0.3 + 0.7*(1/n)) ~= 2.3; assert >= 2x.
+    assert ellipses[-1].major_mm > 2.0 * ellipses[0].major_mm
+    assert ellipses[-1].minor_mm > 2.0 * ellipses[0].minor_mm

--- a/tests/solver/test_assembler.py
+++ b/tests/solver/test_assembler.py
@@ -103,3 +103,28 @@ def test_assemble_summation_of_overlapping_dofs():
     Krr = Kd[np.ix_(free, free)]
     eigs = np.linalg.eigvalsh(Krr)
     assert eigs.min() > 0
+
+
+def test_assembly_sums_shared_dof_contributions_exactly():
+    """Issue #48: a DOF shared by two elements must hold the *sum* of both
+    element stiffness contributions (a +=, not an overwrite), and a DOF
+    touched by only one element must hold exactly that one contribution."""
+    elems, dofs, n_dof = _two_element_system()
+    elem1, elem2 = elems
+    Ke1 = elem1.stiffness_matrix()
+    Ke2 = elem2.stiffness_matrix()
+    K = assemble_global_stiffness(elems, dofs, n_dof).toarray()
+
+    # Global node 1 is shared: local index 1 in element 1, local index 0 in
+    # element 2 (see _two_element_system: e2_nodes[0] == 1). Its global DOFs
+    # are [3, 4, 5].
+    g = [3, 4, 5]
+    e1_loc = [3, 4, 5]  # 3*local_idx(1) + {0,1,2}
+    e2_loc = [0, 1, 2]  # 3*local_idx(0) + {0,1,2}
+    expected_shared = Ke1[np.ix_(e1_loc, e1_loc)] + Ke2[np.ix_(e2_loc, e2_loc)]
+    assert np.allclose(K[np.ix_(g, g)], expected_shared, rtol=0, atol=1e-9)
+
+    # Global node 0 belongs only to element 1 (local index 0) -> single
+    # contribution, must NOT be doubled.
+    g0 = [0, 1, 2]
+    assert np.allclose(K[np.ix_(g0, g0)], Ke1[np.ix_([0, 1, 2], [0, 1, 2])], rtol=0, atol=1e-9)


### PR DESCRIPTION
## Summary

Test coverage for foundational invariants that currently have **no safety net**, plus one robustness guard. Independent of #58/#59; only one production-code change (the #21 guard).

| Issue | Change |
|---|---|
| #47 | hex8 **constant-strain patch test** — `e_xx / e_yy / e_zz / γ_xy`, on the unit cube **and an arbitrarily distorted element** (the distorted case is the one that actually guarantees correct stress recovery on real meshes). Pure test addition. |
| #48 | Assert global assembly **sums** shared-DOF contributions exactly (`K[g,g] == Ke1[loc,loc] + Ke2[loc,loc]`) and that a single-element DOF is **not** doubled. Pure test addition. |
| #16 | Assert the peanut-template **back-face growth axiom**. Uses a constant-angle layup so `aspect_ratio == 1` everywhere, isolating the `_relative_size` ramp (a slope flip/zero would pass every existing test but fail this). Pure test addition. |
| #17 | Assert the **small-mass `m_ratio < 1` Olsson quasi-static `UserWarning`** is actually emitted (params verified: E_onset 8.5 J < 20 J, ratio ≈ 0.4). Pure test addition. |
| #21 | `Laminate.effective_engineering_constants`: raise on an ill-conditioned `A` (`cond > 1e10`) or non-finite/non-positive `Ex/Ey/Gxy/nuxy` instead of silently returning NaN/Inf that corrupts downstream stress recovery; switch `inv` → `solve`. **One production change** + two regression tests (valid laminate still passes; corrupted `_A` raises). |

## Test plan

- [x] `pytest -q` → **308 passed, 1 xfailed** (was 297; +11 new tests).
- [x] `ruff check` + `black --check` clean.
- [x] Patch test passes exactly on a non-affine distorted hex (atol 1e-10).
- [x] #21 guard does not false-trigger on the standard quasi-iso laminate.

https://claude.ai/code/session_01PqfGE89GSnJLETCUxsCdc2

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqfGE89GSnJLETCUxsCdc2)_