### PR TITLE
Olsson robustness + perf: boundary guard, Navier cache (#19 #56 #44)

### DIFF
--- a/src/bvidfe/impact/olsson.py
+++ b/src/bvidfe/impact/olsson.py
@@ -119,9 +119,7 @@ def _k_bending_ssss(
         + 2 * (D12 + 2 * D66) * kx2[:, None] * ky2[None, :]
         + D22 * ky2[None, :] ** 2
     )
-    w_over_P = (4.0 / (a * b)) * np.sum(
-        (sin2_m[:, None] * sin2_n[None, :]) / Dmn
-    )
+    w_over_P = (4.0 / (a * b)) * np.sum((sin2_m[:, None] * sin2_n[None, :]) / Dmn)
     return 1.0 / w_over_P
 
 

--- a/src/bvidfe/impact/olsson.py
+++ b/src/bvidfe/impact/olsson.py
@@ -31,8 +31,11 @@ References:
 
 from __future__ import annotations
 
+import functools
 import math
 import warnings
+
+import numpy as np
 
 from bvidfe.core.geometry import ImpactorGeometry, PanelGeometry
 from bvidfe.core.laminate import Laminate
@@ -59,6 +62,30 @@ _BOUNDARY_BENDING_FACTOR: dict[str, float] = {
 _CONICAL_HALF_ANGLE_DEG: float = 30.0
 
 
+@functools.lru_cache(maxsize=32)
+def _navier_basis_ssss(
+    Lx_mm: float,
+    Ly_mm: float,
+    x0_mm: float,
+    y0_mm: float,
+    n_modes: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Cached Navier modal basis for a simply-supported plate point load.
+
+    Returns ``(sin2_m, sin2_n, kx, ky)`` where ``sin2_m[i] = sin^2(m*pi*x0/a)``,
+    ``kx[i] = m*pi/a`` (and analogously for ``y``). These depend only on the
+    panel geometry, load location and mode count — not on the laminate — so in
+    geometry-fixed sweeps they are bit-identical across calls and cheap to
+    memoise.
+    """
+    m = np.arange(1, n_modes + 1, dtype=float)
+    kx = m * math.pi / Lx_mm
+    ky = m * math.pi / Ly_mm
+    sin2_m = np.sin(kx * x0_mm) ** 2
+    sin2_n = np.sin(ky * y0_mm) ** 2
+    return sin2_m, sin2_n, kx, ky
+
+
 def _k_bending_ssss(
     lam: Laminate,
     pan: PanelGeometry,
@@ -74,21 +101,27 @@ def _k_bending_ssss(
            + D22 * (n*pi/b)^4
     k_bending = 1 / (w/P)
     """
+    a, b = pan.Lx_mm, pan.Ly_mm
+    if not (0.0 < x0 < a and 0.0 < y0 < b):
+        raise ValueError(
+            f"Point load at ({x0}, {y0}) lies on or outside the simply-supported "
+            f"plate boundary [0, {a}] x [0, {b}]; bending compliance there is "
+            f"infinite (every Navier mode vanishes), so k_bending is undefined. "
+            f"Use an interior point 0 < x0 < {a} and 0 < y0 < {b}."
+        )
     _, _, D = lam.abd_matrices()
     D11, D22, D12, D66 = D[0, 0], D[1, 1], D[0, 1], D[2, 2]
-    a, b = pan.Lx_mm, pan.Ly_mm
-    w_over_P = 0.0
-    for m in range(1, n_modes + 1):
-        for n in range(1, n_modes + 1):
-            sin_mx = math.sin(m * math.pi * x0 / a)
-            sin_ny = math.sin(n * math.pi * y0 / b)
-            Dmn = (
-                D11 * (m * math.pi / a) ** 4
-                + 2 * (D12 + 2 * D66) * (m * math.pi / a) ** 2 * (n * math.pi / b) ** 2
-                + D22 * (n * math.pi / b) ** 4
-            )
-            w_over_P += (sin_mx * sin_ny) ** 2 / Dmn
-    w_over_P *= 4.0 / (a * b)
+    sin2_m, sin2_n, kx, ky = _navier_basis_ssss(a, b, x0, y0, n_modes)
+    kx2 = kx**2
+    ky2 = ky**2
+    Dmn = (
+        D11 * kx2[:, None] ** 2
+        + 2 * (D12 + 2 * D66) * kx2[:, None] * ky2[None, :]
+        + D22 * ky2[None, :] ** 2
+    )
+    w_over_P = (4.0 / (a * b)) * np.sum(
+        (sin2_m[:, None] * sin2_n[None, :]) / Dmn
+    )
     return 1.0 / w_over_P
 
 

--- a/tests/impact/test_olsson.py
+++ b/tests/impact/test_olsson.py
@@ -1,10 +1,17 @@
 import dataclasses
 import math
 
+import pytest
+
 from bvidfe.core.geometry import ImpactorGeometry, PanelGeometry
 from bvidfe.core.laminate import Laminate
 from bvidfe.core.material import MATERIAL_LIBRARY
-from bvidfe.impact.olsson import NAVIER_N, onset_energy, threshold_load
+from bvidfe.impact.olsson import (
+    NAVIER_N,
+    _k_bending_ssss,
+    onset_energy,
+    threshold_load,
+)
 
 
 def test_threshold_load_scales_with_sqrt_G_IIc():
@@ -34,6 +41,45 @@ def test_onset_energy_positive_and_monotonic_in_thickness():
 
 def test_navier_n_is_11_by_default():
     assert NAVIER_N == 11
+
+
+@pytest.mark.parametrize(
+    "x0,y0",
+    [(0.0, 50.0), (150.0, 50.0), (75.0, 0.0), (75.0, 100.0), (0.0, 0.0), (150.0, 100.0)],
+)
+def test_k_bending_ssss_rejects_boundary_point(x0, y0):
+    """A point load on the SSSS edge/corner has infinite bending compliance
+    (every Navier sin term vanishes); it must raise rather than divide by 0."""
+    lam = Laminate(MATERIAL_LIBRARY["IM7/8552"], [0, 45, -45, 90] * 2, 0.152)
+    pan = PanelGeometry(150, 100, boundary="simply_supported")
+    with pytest.raises(ValueError, match="boundary"):
+        _k_bending_ssss(lam, pan, x0, y0)
+
+
+def test_k_bending_ssss_matches_reference_scalar_sum():
+    """Cached/vectorised _k_bending_ssss must equal the original scalar
+    double-sum to machine epsilon (issue #56 acceptance)."""
+    lam = Laminate(MATERIAL_LIBRARY["IM7/8552"], [0, 45, -45, 90] * 2, 0.152)
+    pan = PanelGeometry(150, 100, boundary="simply_supported")
+    x0, y0 = 61.0, 43.0
+    n_modes = NAVIER_N
+    _, _, D = lam.abd_matrices()
+    D11, D22, D12, D66 = D[0, 0], D[1, 1], D[0, 1], D[2, 2]
+    a, b = pan.Lx_mm, pan.Ly_mm
+    w_over_P = 0.0
+    for m in range(1, n_modes + 1):
+        for n in range(1, n_modes + 1):
+            sin_mx = math.sin(m * math.pi * x0 / a)
+            sin_ny = math.sin(n * math.pi * y0 / b)
+            Dmn = (
+                D11 * (m * math.pi / a) ** 4
+                + 2 * (D12 + 2 * D66) * (m * math.pi / a) ** 2 * (n * math.pi / b) ** 2
+                + D22 * (n * math.pi / b) ** 4
+            )
+            w_over_P += (sin_mx * sin_ny) ** 2 / Dmn
+    w_over_P *= 4.0 / (a * b)
+    ref = 1.0 / w_over_P
+    assert _k_bending_ssss(lam, pan, x0, y0) == pytest.approx(ref, rel=1e-15, abs=0.0)
 
 
 def test_onset_energy_scales_with_material_G_IIc():

--- a/tests/validation/test_olsson_threshold_reference.py
+++ b/tests/validation/test_olsson_threshold_reference.py
@@ -84,23 +84,23 @@ def test_threshold_load_invariant_to_panel_size():
     assert Pc_small == pytest.approx(Pc_large, rel=1e-12)
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Empirical ratio is ~2.65 vs theoretical 2^{3/2}=2.83 (~6.5% off). "
-        "Either Pc has a sub-h^{3/2} contribution from the ply-by-ply "
-        "Q_bar→D_eff path, or the test's 1% tolerance is too tight for the "
-        "discrete-stack case. Needs maintainer review of model vs scaling law."
-    ),
-    strict=True,
-)
 def test_threshold_load_scales_with_thickness_to_the_three_halves():
-    """Doubling the layup count (same material, same angles) raises h
-    by the layup-count factor; D_eff scales as h^3, Pc as h^{3/2}."""
+    """Pc ~ h^{3/2} under *homogeneous* thickness scaling (exact CLT).
+
+    Pc = pi*sqrt(8*G_IIc*D_eff/9) with D_eff = sqrt(D11*D22), and the D
+    matrix is sum_k Qbar_k*(z_k^3 - z_{k-1}^3)/3. The h^3 (hence Pc ~ h^{3/2})
+    law is exact ONLY when the through-thickness Qbar(z) distribution is
+    preserved under scaling — i.e. the SAME layup with thicker plies. It is
+    NOT a property of "doubling the ply count": [0,45,-45,90]*2 is a
+    different stacking sequence (the 0 ply moves off the surface), so its
+    D_eff/h^3 is not unity (here D_eff ratio ~7.0, giving Pc ratio ~2.65 =
+    sqrt(7), which is correct physics, not a bug). We therefore scale h
+    homogeneously by doubling t_ply with the layup held fixed."""
     base_layup = [0, 45, -45, 90]
-    lam_thin = _laminate("IM7/8552", base_layup)  # 4 plies
-    lam_thick = _laminate("IM7/8552", base_layup * 2)  # 8 plies
+    lam_thin = _laminate("IM7/8552", base_layup, t_ply=0.152)
+    lam_thick = _laminate("IM7/8552", base_layup, t_ply=0.304)  # exact h -> 2h
     pan, imp = _panel(), _impactor()
     Pc_thin = threshold_load(lam_thin, pan, imp)
     Pc_thick = threshold_load(lam_thick, pan, imp)
-    # h_thick / h_thin = 2 -> Pc_thick / Pc_thin = 2^{3/2} = 2.828...
-    assert Pc_thick / Pc_thin == pytest.approx(2**1.5, rel=1e-2)
+    # h_thick / h_thin = 2 -> Pc_thick / Pc_thin = 2^{3/2} = 2.828... (exact)
+    assert Pc_thick / Pc_thin == pytest.approx(2**1.5, rel=1e-9)


### PR DESCRIPTION
## Summary

- **#19** — `_k_bending_ssss` entry guard: raises a clear `ValueError` when the load is on/outside the SSSS boundary (`not (0 < x0 < a and 0 < y0 < b)`), where bending compliance is physically infinite (was a `ZeroDivisionError` crashing the impact pipeline on legal input). Verified `mapping.py`'s `(0,0)→centre` remap runs first, so legal input is unaffected.
- **#56** — `@functools.lru_cache(maxsize=32)` helper `_navier_basis_ssss`; `_k_bending_ssss` rewritten as a vectorised numpy outer product. Guard from #19 runs before the cache lookup. Regression test asserts machine-ε identity (rel=1e-15) vs. the original scalar double-sum.
- **#44** — **conclusion: no physics bug.** `threshold_load = π·√(8·G_IIc·D_eff/9)` never touches `kc`/`kb`, so the issue's `1/Pc²∝1/kc+1/kb` framing doesn't apply. `Pc ∝ h^1.5` is exact CLT only under *homogeneous* scaling (same layup, thicker plies). The old test doubled the ply **count** (`[0,45,-45,90]*2`), reshuffling the stacking sequence → D_eff ratio 7.0 → Pc ratio √7≈2.65 (correct physics; the test's `2^1.5` expectation was wrong). `xfail` removed; test rewritten to scale `t_ply` 0.152→0.304 with layup fixed → ratio exactly `2^1.5` (rel=1e-9), with a physics comment recording the reasoning.

> **Reviewer note (#44):** this changes only the test, not production code, on the basis that the test asserted the scaling law under the wrong (count-doubling) regime. If you prefer #44 stay a tracked investigation, revert the test change and we'll reinstate the `xfail`.

Full suite: **316 passed, 0 xfailed** (the old xfail is now a real passing assertion; +7 tests). ruff clean.

## Test plan

- [ ] CI green on the branch
- [ ] Reviewer ratifies the #44 physics conclusion (or requests revert)
- [ ] Confirm boundary-guard `ValueError` message is user-actionable

https://claude.ai/code/session_01PqfGE89GSnJLETCUxsCdc2

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqfGE89GSnJLETCUxsCdc2)_