### PR TITLE
Physics: orthotropic Whitney–Nuismer Kt∞ via Lekhnitskii (#30)

### DIFF
--- a/src/bvidfe/analysis/bvid.py
+++ b/src/bvidfe/analysis/bvid.py
@@ -21,7 +21,11 @@ from bvidfe.analysis.semi_analytical import (
 from bvidfe.core.laminate import Laminate
 from bvidfe.core.material import MATERIAL_LIBRARY, OrthotropicMaterial
 from bvidfe.damage.state import DamageState
-from bvidfe.failure.soutis_openhole import soutis_cai, whitney_nuismer_tai
+from bvidfe.failure.soutis_openhole import (
+    lekhnitskii_kt_infinity,
+    soutis_cai,
+    whitney_nuismer_tai,
+)
 from bvidfe.impact.mapping import impact_to_damage
 
 
@@ -162,4 +166,5 @@ class BvidAnalysis:
         mat = lam.material
         if self.config.loading == "compression":
             return soutis_cai(mat, dpa, A_panel, sigma_0)
-        return whitney_nuismer_tai(mat, dpa, sigma_0)
+        Kt_inf = lekhnitskii_kt_infinity(lam)
+        return whitney_nuismer_tai(mat, dpa, sigma_0, Kt_inf)

--- a/src/bvidfe/analysis/semi_analytical.py
+++ b/src/bvidfe/analysis/semi_analytical.py
@@ -21,7 +21,11 @@ import numpy as np
 from bvidfe.core.laminate import Laminate
 from bvidfe.core.material import OrthotropicMaterial
 from bvidfe.damage.state import DamageState, DelaminationEllipse
-from bvidfe.failure.soutis_openhole import soutis_cai, whitney_nuismer_tai
+from bvidfe.failure.soutis_openhole import (
+    lekhnitskii_kt_infinity,
+    soutis_cai,
+    whitney_nuismer_tai,
+)
 
 # Sublaminate buckling coefficient multiplier on the SSSS Rayleigh-Ritz result
 # for other panel boundary conditions. The delaminated sublaminate's edge
@@ -227,4 +231,5 @@ def semi_analytical_tai(
     deferred to v0.2.0.
     """
     dpa = damage.projected_damage_area_mm2
-    return whitney_nuismer_tai(lam.material, dpa, sigma_pristine_MPa)
+    Kt_inf = lekhnitskii_kt_infinity(lam)
+    return whitney_nuismer_tai(lam.material, dpa, sigma_pristine_MPa, Kt_inf)

--- a/src/bvidfe/failure/soutis_openhole.py
+++ b/src/bvidfe/failure/soutis_openhole.py
@@ -6,14 +6,31 @@ CAI knockdown (Soutis & Curtis 1996):
 TAI via equivalent open hole (Whitney & Nuismer 1974, point-stress criterion):
     sigma_N / sigma_0 = 2 / (2 + xi^2 + 3*xi^4 - (Kt_inf - 3)*(5*xi^6 - 7*xi^8))
 where xi = R / (R + d0), R = sqrt(DPA/pi), d0 = material characteristic distance,
-Kt_inf = infinite-plate stress concentration (3.0 for isotropic).
+Kt_inf = infinite-plate stress concentration (3.0 for isotropic; for orthotropic
+laminates use ``lekhnitskii_kt_infinity``).
 """
 
 from __future__ import annotations
 
 import math
+import warnings
 
+from bvidfe.core.laminate import Laminate
 from bvidfe.core.material import OrthotropicMaterial
+
+
+def lekhnitskii_kt_infinity(lam: Laminate) -> float:
+    """Infinite-plate stress concentration factor for an orthotropic laminate.
+
+    Whitney & Nuismer's orthotropic form (Lekhnitskii anisotropic elasticity):
+
+        Kt_inf = 1 + sqrt( 2*(sqrt(Ex/Ey) - nuxy) + Ex/Gxy )
+
+    reduces to the isotropic value 3.0 for a quasi-isotropic laminate. The
+    engineering constants are taken from ``lam.effective_engineering_constants``.
+    """
+    Ex, Ey, Gxy, nuxy = lam.effective_engineering_constants()
+    return 1.0 + math.sqrt(2.0 * (math.sqrt(Ex / Ey) - nuxy) + Ex / Gxy)
 
 
 def soutis_cai(
@@ -40,15 +57,29 @@ def whitney_nuismer_tai(
     m: OrthotropicMaterial,
     dpa_mm2: float,
     sigma_pristine_MPa: float,
-    Kt_inf: float = 3.0,
+    Kt_inf: float | None = None,
 ) -> float:
     """Tension-after-impact via Whitney-Nuismer point-stress on an equivalent
     circular hole of diameter 2*sqrt(DPA/pi).
+
+    ``Kt_inf`` is the infinite-plate stress concentration factor; callers
+    should pass the orthotropic value from ``lekhnitskii_kt_infinity``. When
+    left as ``None`` it falls back to the isotropic value 3.0 and a
+    ``UserWarning`` is emitted, since that is unconservative for CFRP.
 
     Used by both the ``empirical`` and ``semi_analytical`` tiers for TAI
     (the semi-analytical TAI path delegates here unchanged), so those two
     tiers report mathematically identical knockdown values for tension.
     """
+    if Kt_inf is None:
+        warnings.warn(
+            "whitney_nuismer_tai called without Kt_inf; falling back to the "
+            "isotropic value 3.0. This underpredicts the notch sensitivity of "
+            "orthotropic CFRP laminates. Pass lekhnitskii_kt_infinity(lam).",
+            UserWarning,
+            stacklevel=2,
+        )
+        Kt_inf = 3.0
     if dpa_mm2 <= 0:
         return sigma_pristine_MPa
     R = math.sqrt(dpa_mm2 / math.pi)

--- a/tests/failure/test_soutis.py
+++ b/tests/failure/test_soutis.py
@@ -1,7 +1,12 @@
 import math
 
+from bvidfe.core.laminate import Laminate
 from bvidfe.core.material import MATERIAL_LIBRARY
-from bvidfe.failure.soutis_openhole import soutis_cai, whitney_nuismer_tai
+from bvidfe.failure.soutis_openhole import (
+    lekhnitskii_kt_infinity,
+    soutis_cai,
+    whitney_nuismer_tai,
+)
 
 
 def test_soutis_monotone_decreasing_in_dpa():
@@ -41,3 +46,19 @@ def test_wn_tai_pristine_strength_cap():
     m = MATERIAL_LIBRARY["IM7/8552"]
     s = whitney_nuismer_tai(m, dpa_mm2=200, sigma_pristine_MPa=800)
     assert 0 < s < 800
+
+
+def test_lekhnitskii_kt_unidirectional_exceeds_isotropic():
+    """Issue #30: a highly orthotropic IM7/8552 [0]_8 stack must have an
+    infinite-plate Kt well above the isotropic value 3.0."""
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    lam = Laminate(m, [0] * 8, 0.152)
+    assert lekhnitskii_kt_infinity(lam) > 3.0
+
+
+def test_lekhnitskii_kt_quasi_iso_reduces_to_isotropic():
+    """Issue #30: a quasi-isotropic layup must collapse to the isotropic
+    Kt_inf = 3.0."""
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    lam = Laminate(m, [0, 45, -45, 90] * 2, 0.125)
+    assert math.isclose(lekhnitskii_kt_infinity(lam), 3.0, rel_tol=1e-3)


### PR DESCRIPTION
## Summary

- **#30** — Whitney–Nuismer no longer hardcodes the isotropic `Kt∞ = 3.0`. Added `lekhnitskii_kt_infinity(lam)` in `failure/soutis_openhole.py` computing `Kt∞ = 1 + √(2·(√(Ex/Ey) − νxy) + Ex/Gxy)` from `lam.effective_engineering_constants()`. Wired through `semi_analytical_tai` and `bvid._empirical` (edits confined to the call-site regions, away from the #20 zone). `whitney_nuismer_tai` now takes `Kt_inf=None`, emitting a `UserWarning` and falling back to 3.0 only as an explicit override. Regression tests added in `tests/failure/test_soutis.py`.
- **#21** — already implemented on `main` via merged PR #60 (A-matrix conditioning guard); verified it meets the spec, no change needed. This PR consumes those hardened engineering constants.

Observed `Kt∞`: IM7/8552 [0]₈ → **7.14** (correctly high for fiber-dominated); quasi-iso [0/45/-45/90]₂ → **3.00** (correctly ≈ isotropic). Previously both were 3.0 → non-conservative TAI for fiber-dominated stacks.

Full suite: **310 passed, 1 xfailed**. ruff + black clean.

## Test plan

- [ ] CI green on the branch
- [ ] Reviewer sanity-checks the Lekhnitskii expression and the two reference Kt∞ values
- [ ] Confirm TAI residuals shift in the conservative direction for 0°-dominated layups

https://claude.ai/code/session_01PqfGE89GSnJLETCUxsCdc2

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqfGE89GSnJLETCUxsCdc2)_