### PR TITLE
olsson: guard SSSS bending compliance singularity at panel boundary (#19)

### DIFF
--- a/src/bvidfe/impact/olsson.py
+++ b/src/bvidfe/impact/olsson.py
@@ -77,6 +77,11 @@ def _k_bending_ssss(
     _, _, D = lam.abd_matrices()
     D11, D22, D12, D66 = D[0, 0], D[1, 1], D[0, 1], D[2, 2]
     a, b = pan.Lx_mm, pan.Ly_mm
+    if not (0.0 < x0 < a and 0.0 < y0 < b):
+        raise ValueError(
+            f"impact location ({x0}, {y0}) must lie strictly inside the panel "
+            f"(0, {a}) x (0, {b}); SSSS bending compliance is singular at the boundary."
+        )
     w_over_P = 0.0
     for m in range(1, n_modes + 1):
         for n in range(1, n_modes + 1):

--- a/tests/impact/test_olsson.py
+++ b/tests/impact/test_olsson.py
@@ -1,10 +1,12 @@
 import dataclasses
 import math
 
+import pytest
+
 from bvidfe.core.geometry import ImpactorGeometry, PanelGeometry
 from bvidfe.core.laminate import Laminate
 from bvidfe.core.material import MATERIAL_LIBRARY
-from bvidfe.impact.olsson import NAVIER_N, onset_energy, threshold_load
+from bvidfe.impact.olsson import NAVIER_N, _k_bending_ssss, onset_energy, threshold_load
 
 
 def test_threshold_load_scales_with_sqrt_G_IIc():
@@ -47,3 +49,35 @@ def test_onset_energy_scales_with_material_G_IIc():
     E2 = onset_energy(lam2, pan, imp)
     # onset energy ∝ Pc^2 ∝ G_IIc, so 4x => 4x (approximately)
     assert E2 > E1
+
+
+@pytest.mark.parametrize(
+    "x0, y0",
+    [
+        (0.0, 0.0),  # corner (origin)
+        (150.0, 100.0),  # opposite corner (Lx, Ly)
+        (0.0, 50.0),  # mid-left edge (x0 == 0)
+        (75.0, 100.0),  # top edge (y0 == Ly)
+        (-1.0, 50.0),  # outside the panel
+    ],
+)
+def test_k_bending_ssss_boundary_raises_valueerror(x0, y0):
+    """A point load on/outside the SSSS plate boundary is degenerate: the
+    bending compliance is singular, so we raise ValueError rather than
+    crashing with ZeroDivisionError (issue #19)."""
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    lam = Laminate(m, [0, 45, -45, 90] * 4, 0.152)
+    pan = PanelGeometry(150, 100)
+    with pytest.raises(ValueError, match="singular at the boundary"):
+        _k_bending_ssss(lam, pan, x0, y0)
+
+
+def test_k_bending_ssss_interior_returns_finite_positive():
+    """Regression guard: a normal interior location still yields a finite,
+    strictly positive bending stiffness."""
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    lam = Laminate(m, [0, 45, -45, 90] * 4, 0.152)
+    pan = PanelGeometry(150, 100)
+    k = _k_bending_ssss(lam, pan, 75.0, 50.0)
+    assert math.isfinite(k)
+    assert k > 0.0


### PR DESCRIPTION
## Summary

Fixes **#19**. `_k_bending_ssss` in `src/bvidfe/impact/olsson.py` computes the SSSS Navier point-load compliance as a `sin²` series and returns `1.0 / w_over_P`. For any impact location on a panel edge or corner — `(0,0)`, `(Lx,Ly)`, `(0,y)`, `(x,Ly)` — every sine term is exactly zero, so `w_over_P == 0.0` and the function blew up (`ZeroDivisionError` / non-physical `inf`), crashing the impact-mapping pipeline on legal user input. `mapping.py` only special-cased `(0,0)`.

This adds a strict-interior validation at function entry that raises a clear `ValueError` (a point load at the simply-supported plate boundary is physically degenerate — bending compliance is singular there):

```python
if not (0.0 < x0 < a and 0.0 < y0 < b):
    raise ValueError(
        f"impact location ({x0}, {y0}) must lie strictly inside the panel "
        f"(0, {a}) x (0, {b}); SSSS bending compliance is singular at the boundary."
    )
```

Call sites (`onset_energy`, `mapping.impact_to_damage`) remap default/origin locations to the panel centre before reaching this function, so legitimate internal flows are unaffected; only explicit user-supplied boundary points now fail loudly instead of crashing.

## Changes

- `src/bvidfe/impact/olsson.py` — strict-interior guard in `_k_bending_ssss` (+5).
- `tests/impact/test_olsson.py` — parametrized boundary/corner/outside cases assert `ValueError`; interior-location regression guard asserts finite, positive stiffness (+36/−1).

## Verification

- `ruff check src tests` — clean
- `black --check src tests` — clean
- `pytest` — **317 passed, 1 xfailed** (baseline `main` was 311 passed; +6 new cases, zero regressions)

## Note on the other audited issues

This work began as a 5-issue batch (#16, #19, #21, #47, #48). On audit against current `main`, **#16, #21, #47 and #48 are already resolved** by previously merged work and were only left open — their fixes are present and cite the issue numbers directly:

- **#16** — `tests/impact/test_shape_templates.py::test_back_face_growth_axiom` (docstring: "Issue #16")
- **#21** — `Laminate.effective_engineering_constants` already has the `np.linalg.cond > 1e10` guard, `np.linalg.solve`, and finite/positive validation
- **#47** — `tests/elements/test_hex8.py::test_hex8_constant_strain_patch_test_unit_cube` (+ distorted-element variant)
- **#48** — `tests/solver/test_assembler.py::test_assembly_sums_shared_dof_contributions_exactly` (docstring: "Issue #48")

Recommend closing #16, #21, #47, #48 as already-fixed. This PR contains only the genuinely-open #19.

https://claude.ai/code/session_01DKENPtYDqmhbGbo4AcFbfZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKENPtYDqmhbGbo4AcFbfZ)_