### PR TITLE
Collapse tension_bcs alias (#40) + CLI multi-tier comparison (#39)

### DIFF
--- a/src/bvidfe/analysis/bvid.py
+++ b/src/bvidfe/analysis/bvid.py
@@ -127,8 +127,8 @@ class BvidAnalysis:
                 sigma = fe3d_tai(self.config, damage, lam, sigma_0)
                 buckling_eigs = None
                 fpf_governs = True
-            # The FPF / TAI BC builders (compression_bcs / tension_bcs) do
-            # not yet honour cfg.panel.boundary — only the buckling path
+            # The FPF / TAI BC builder (uniaxial_x_bcs) does not yet honour
+            # cfg.panel.boundary — only the buckling path
             # does. When the reported residual comes from FPF/TAI and a
             # non-default boundary was requested, surface that it had no
             # effect rather than letting it look silently applied (#32).

--- a/src/bvidfe/analysis/fe_tier.py
+++ b/src/bvidfe/analysis/fe_tier.py
@@ -26,8 +26,7 @@ from bvidfe.solver.assembler import assemble_global_stiffness
 from bvidfe.solver.boundary import (
     BoundaryCondition,
     apply_dirichlet_penalty,
-    compression_bcs,
-    tension_bcs,
+    uniaxial_x_bcs,
 )
 from bvidfe.solver.buckling import linear_buckling
 from bvidfe.solver.static import solve_linear_static
@@ -246,10 +245,7 @@ def _solve_failure_strain_analytic(
     material = _resolve_material(cfg)
 
     # One FE solve at reference strain = strain_sign * strain_cap
-    if criterion == "larc05":
-        bcs = compression_bcs(mesh.node_coords, strain_sign * strain_cap)
-    else:
-        bcs = tension_bcs(mesh.node_coords, strain_sign * strain_cap)
+    bcs = uniaxial_x_bcs(mesh.node_coords, strain_sign * strain_cap)
     u_ref = solve_linear_static(elements, mesh.element_dof_maps, mesh.n_dof, bcs)
 
     c_crit_min = np.inf
@@ -322,10 +318,7 @@ def _solve_failure_strain_analytic_scalar_ref(
     """
     material = _resolve_material(cfg)
 
-    if criterion == "larc05":
-        bcs = compression_bcs(mesh.node_coords, strain_sign * strain_cap)
-    else:
-        bcs = tension_bcs(mesh.node_coords, strain_sign * strain_cap)
+    bcs = uniaxial_x_bcs(mesh.node_coords, strain_sign * strain_cap)
     u_ref = solve_linear_static(elements, mesh.element_dof_maps, mesh.n_dof, bcs)
 
     c_crit_min = np.inf

--- a/src/bvidfe/cli.py
+++ b/src/bvidfe/cli.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from dataclasses import replace
 from typing import List, Sequence
 
 import bvidfe
@@ -59,6 +60,31 @@ def _existing_path(spec: str):
     return p
 
 
+_VALID_TIERS = ("empirical", "semi_analytical", "fe3d")
+
+
+def _parse_tiers(spec: str) -> List[str]:
+    """Parse ``--tier`` as one tier or a comma-separated list to compare.
+
+    Validated against the known tiers, order-preserving, and de-duplicated
+    so ``--tier empirical,empirical`` doesn't run the same solve twice.
+    """
+    tiers: List[str] = []
+    for raw in spec.split(","):
+        t = raw.strip()
+        if not t:
+            continue
+        if t not in _VALID_TIERS:
+            raise argparse.ArgumentTypeError(
+                f"unknown tier {t!r}; choose from {', '.join(_VALID_TIERS)}"
+            )
+        if t not in tiers:
+            tiers.append(t)
+    if not tiers:
+        raise argparse.ArgumentTypeError("--tier must name at least one tier")
+    return tiers
+
+
 def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="bvidfe",
@@ -99,9 +125,12 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--tier",
-        default="empirical",
-        choices=["empirical", "semi_analytical", "fe3d"],
-        help="Analysis fidelity tier",
+        type=_parse_tiers,
+        default=["empirical"],
+        help="Analysis fidelity tier(s). A single tier (e.g. semi_analytical) "
+        "or a comma-separated list to compare in one invocation (e.g. "
+        "empirical,semi_analytical,fe3d). Choices: empirical, semi_analytical, "
+        "fe3d.",
     )
     p.add_argument(
         "--energy",
@@ -186,7 +215,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             ply_thickness_mm=args.thickness,
             panel=args.panel,
             loading=args.loading,
-            tier=args.tier,
+            tier=args.tier[0],
             impact=ImpactEvent(
                 energy_J=args.energy,
                 impactor=ImpactorGeometry(diameter_mm=args.impactor_diameter),
@@ -204,27 +233,41 @@ def main(argv: Sequence[str] | None = None) -> int:
             ply_thickness_mm=args.thickness,
             panel=args.panel,
             loading=args.loading,
-            tier=args.tier,
+            tier=args.tier[0],
             damage=damage,
         )
     if args.quick and args.quick_json:
         parser.error("--quick and --quick-json are mutually exclusive")
-    result = BvidAnalysis(cfg).run()
+
+    # One result per requested tier. Single-tier output is byte-identical to
+    # the pre-multi-tier behaviour; multiple tiers switch to a comparison
+    # shape (JSON array / NDJSON / TSV) keyed by tier_used.
+    results = [BvidAnalysis(replace(cfg, tier=t)).run() for t in args.tier]
+    multi = len(results) > 1
+
     if args.quick_json:
-        json.dump(
-            {
-                "knockdown": result.knockdown,
-                "residual_strength_MPa": result.residual_strength_MPa,
-                "pristine_strength_MPa": result.pristine_strength_MPa,
-                "tier_used": result.tier_used,
-            },
-            sys.stdout,
-        )
-        sys.stdout.write("\n")
+        for result in results:
+            json.dump(
+                {
+                    "knockdown": result.knockdown,
+                    "residual_strength_MPa": result.residual_strength_MPa,
+                    "pristine_strength_MPa": result.pristine_strength_MPa,
+                    "tier_used": result.tier_used,
+                },
+                sys.stdout,
+            )
+            sys.stdout.write("\n")
     elif args.quick:
-        print(f"{result.knockdown:.6f}")
+        for result in results:
+            if multi:
+                print(f"{result.tier_used}\t{result.knockdown:.6f}")
+            else:
+                print(f"{result.knockdown:.6f}")
     else:
-        json.dump(result.to_dict(), sys.stdout, indent=2, default=str)
+        if multi:
+            json.dump([r.to_dict() for r in results], sys.stdout, indent=2, default=str)
+        else:
+            json.dump(results[0].to_dict(), sys.stdout, indent=2, default=str)
         sys.stdout.write("\n")
     return 0
 

--- a/src/bvidfe/solver/boundary.py
+++ b/src/bvidfe/solver/boundary.py
@@ -1,8 +1,9 @@
 """Displacement-controlled boundary conditions applied via penalty method.
 
 Standard patterns:
-- compression_bcs: clamp x_min, prescribe u_x at x_max (+ symmetry on y_min, z_min).
-- tension_bcs:     same as compression but with positive strain.
+- uniaxial_x_bcs: clamp x_min, prescribe u_x at x_max (+ symmetry on y_min,
+  z_min). The sign of ``applied_strain`` selects compression (negative) or
+  tension (positive) — the BC topology is identical either way.
 - apply_dirichlet_penalty: multiply K[i,i] by penalty and F[i] = penalty * value.
 """
 
@@ -61,11 +62,16 @@ def _nodes_on_plane(
     return np.where(np.abs(node_coords[:, axis] - coord) < tol)[0]
 
 
-def compression_bcs(node_coords: np.ndarray, applied_strain: float) -> List[BoundaryCondition]:
-    """Build BCs for a uniaxial compression test along x.
+def uniaxial_x_bcs(node_coords: np.ndarray, applied_strain: float) -> List[BoundaryCondition]:
+    """Build BCs for a uniaxial test along x (compression or tension).
+
+    The sign of ``applied_strain`` is the only difference between the
+    compression and tension load cases — the constrained-DOF topology is
+    identical, so a single builder serves both:
 
     - x_min nodes: u_x = 0 (clamped)
-    - x_max nodes: u_x = applied_strain * Lx  (negative for compression)
+    - x_max nodes: u_x = applied_strain * Lx  (negative = compression,
+      positive = tension)
     - y_min nodes: u_y = 0 (symmetry)
     - z_min nodes: u_z = 0 (symmetry)
     """
@@ -85,8 +91,3 @@ def compression_bcs(node_coords: np.ndarray, applied_strain: float) -> List[Boun
     for n in zmin_nodes:
         bcs.append(BoundaryCondition(dof=3 * int(n) + 2, value=0.0))
     return bcs
-
-
-def tension_bcs(node_coords: np.ndarray, applied_strain: float) -> List[BoundaryCondition]:
-    """Build BCs for a uniaxial tension test along x. Same structure, positive strain."""
-    return compression_bcs(node_coords, applied_strain=applied_strain)

--- a/tests/analysis/test_fpf_strain_solve_equivalence.py
+++ b/tests/analysis/test_fpf_strain_solve_equivalence.py
@@ -90,8 +90,9 @@ def test_vectorised_matches_scalar_reference(criterion, damage):
 
 
 def test_vectorised_tension_path_also_matches_scalar_reference():
-    """The tension path uses tension_bcs and Tsai-Wu by default; verify the
-    vectorised form is still equivalent under the +strain_sign branch."""
+    """The tension path uses uniaxial_x_bcs (positive strain) and Tsai-Wu by
+    default; verify the vectorised form is still equivalent under the
+    +strain_sign branch."""
     damage = DamageState(
         delaminations=[DelaminationEllipse(1, (10, 5), 6, 3, 0)],
         dent_depth_mm=0.0,

--- a/tests/solver/test_boundary.py
+++ b/tests/solver/test_boundary.py
@@ -4,8 +4,7 @@ import scipy.sparse as sp
 from bvidfe.solver.boundary import (
     BoundaryCondition,
     apply_dirichlet_penalty,
-    compression_bcs,
-    tension_bcs,
+    uniaxial_x_bcs,
 )
 
 
@@ -20,7 +19,7 @@ def test_apply_dirichlet_penalty_enforces_prescribed_value():
     assert abs(u[2] - (-0.5)) < 1e-6
 
 
-def test_compression_bcs_returns_xmin_and_xmax_bcs():
+def test_uniaxial_x_bcs_compression_returns_xmin_and_xmax_bcs():
     # 8 nodes of a unit cube
     node_coords = np.array(
         [
@@ -35,7 +34,7 @@ def test_compression_bcs_returns_xmin_and_xmax_bcs():
         ],
         dtype=float,
     )
-    bcs = compression_bcs(node_coords, applied_strain=-0.01)
+    bcs = uniaxial_x_bcs(node_coords, applied_strain=-0.01)
     # 4 nodes on x_min get u_x=0, 4 nodes on x_max get u_x=-0.01*Lx=-0.01
     xmin_bcs = [b for b in bcs if abs(b.value) < 1e-12]
     xmax_bcs = [b for b in bcs if abs(b.value - (-0.01)) < 1e-6]
@@ -43,7 +42,7 @@ def test_compression_bcs_returns_xmin_and_xmax_bcs():
     assert len(xmax_bcs) == 4
 
 
-def test_tension_bcs_positive_displacement():
+def test_uniaxial_x_bcs_tension_positive_displacement():
     node_coords = np.array(
         [
             [0, 0, 0],
@@ -57,6 +56,6 @@ def test_tension_bcs_positive_displacement():
         ],
         dtype=float,
     )
-    bcs = tension_bcs(node_coords, applied_strain=0.005)
+    bcs = uniaxial_x_bcs(node_coords, applied_strain=0.005)
     xmax = [b for b in bcs if abs(b.value - (0.005 * 2)) < 1e-6]
     assert len(xmax) == 4

--- a/tests/solver/test_static.py
+++ b/tests/solver/test_static.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from bvidfe.core.material import MATERIAL_LIBRARY
 from bvidfe.elements.hex8 import Hex8Element
-from bvidfe.solver.boundary import compression_bcs
+from bvidfe.solver.boundary import uniaxial_x_bcs
 from bvidfe.solver.static import solve_linear_static
 
 
@@ -34,7 +34,7 @@ def test_solve_compression_returns_prescribed_displacement_at_xmax():
     """Test that prescribed displacement is achieved at x_max."""
     node_coords, elems, dofs, m = _single_cube_model()
     n_dof = 3 * node_coords.shape[0]
-    bcs = compression_bcs(node_coords, applied_strain=-0.01)
+    bcs = uniaxial_x_bcs(node_coords, applied_strain=-0.01)
     u = solve_linear_static(elems, dofs, n_dof, bcs)
     assert u.shape == (n_dof,)
     # Node 1 is at x=1 (x_max); u_x should be ≈ -0.01
@@ -45,7 +45,7 @@ def test_solve_preserves_rigid_y_displacement_at_xmin():
     """Test that clamped boundary conditions are preserved at x_min."""
     node_coords, elems, dofs, m = _single_cube_model()
     n_dof = 3 * node_coords.shape[0]
-    bcs = compression_bcs(node_coords, applied_strain=-0.01)
+    bcs = uniaxial_x_bcs(node_coords, applied_strain=-0.01)
     u = solve_linear_static(elems, dofs, n_dof, bcs)
     # Node 0 at x=y=z=0: u_x=u_y=u_z=0
     for k in range(3):
@@ -57,7 +57,7 @@ def test_solve_axial_strain_matches_prescribed_for_single_cube():
     node_coords, elems, dofs, m = _single_cube_model()
     n_dof = 3 * node_coords.shape[0]
     applied_strain = -0.01
-    bcs = compression_bcs(node_coords, applied_strain=applied_strain)
+    bcs = uniaxial_x_bcs(node_coords, applied_strain=applied_strain)
     u = solve_linear_static(elems, dofs, n_dof, bcs)
     # Node 2 at x=1: u_x ≈ applied_strain * Lx
     assert abs(u[3 * 2 + 0] - applied_strain) < 1e-3


### PR DESCRIPTION
Two independent, low-risk fixes from the open-issue triage. One combined branch as requested.

## #40 — Collapse `tension_bcs` into `uniaxial_x_bcs`

`tension_bcs` was a verbatim forwarder to `compression_bcs` (identical signature/output); the load case is determined solely by the sign of `applied_strain`. Worse, `fe_tier.py` had `if criterion == "larc05": compression_bcs(...) else: tension_bcs(...)` — both arms identical, so a future sign edit to `tension_bcs` would have silently changed compression callers.

Chose the **collapse** path from the issue:
- `solver/boundary.py`: rename `compression_bcs` → `uniaxial_x_bcs`, explicit BC-topology + sign-convention docstring; delete `tension_bcs`; update module docstring.
- `analysis/fe_tier.py`: import `uniaxial_x_bcs`; drop both dead `if criterion` BC-selection branches (the separate `criterion`-based failure-index selection is untouched).
- `analysis/bvid.py`: corrected the stale `(compression_bcs / tension_bcs)` comment.
- Tests: `tests/solver/test_boundary.py` (two tests now exercise `uniaxial_x_bcs` with negative=compression / positive=tension), `tests/solver/test_static.py`, and a docstring in `test_fpf_strain_solve_equivalence.py`.

## #39 — CLI multi-tier comparison

`--tier` now accepts a comma-separated list (validated against the known tiers, order-preserving, de-duplicated). **Single-tier output is byte-identical to the previous behaviour.** Multiple tiers switch to a comparison shape keyed by `tier_used`:
- default → JSON array
- `--quick-json` → NDJSON (one object per line)
- `--quick` → tab-separated `tier_used<TAB>knockdown` per line

`cli.py`: added `_parse_tiers`, changed the `--tier` arg, and loop via `dataclasses.replace(cfg, tier=t)`.

## Verification

- `ruff check src tests` — clean
- `black --check src tests` — clean
- `pytest` — **317 passed, 1 xfailed** (no regressions vs `main`; no stale `compression_bcs`/`tension_bcs` references remain anywhere)
- CLI smoke-tested: single-tier `--quick`/`--quick-json`/default identical to before; multi-tier JSON-array / NDJSON / TSV correct; `empirical,empirical` de-dupes; unknown tier → clean argparse error.

Closes #39, closes #40.

https://claude.ai/code/session_01DKENPtYDqmhbGbo4AcFbfZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKENPtYDqmhbGbo4AcFbfZ)_