### PR TITLE
docs: drop stale hard-coded test count from CHANGELOG (#28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,10 @@ In-progress work toward v0.2.0. No tag yet.
   validated datasets in v0.1.0" — three statements that were correct
   for v0.1.0 but stale for v0.2.0-dev (where the GUI ships, the
   buckling eigensolve is implemented, and the validation harness is in
-  the repo). The test-count badge advertised 216 passing; the actual
-  count is 309. ``ARCHITECTURE.md``'s module catalog had no entry for
+  the repo). The hard-coded test-count badge ("216 passing", stale the
+  moment the suite grew) was replaced with a CI-driven GitHub Actions
+  workflow status shield that updates automatically.
+  ``ARCHITECTURE.md``'s module catalog had no entry for
   the ``gui/`` package, the dependency diagram did not reach ``cli``
   or ``gui``, and the v0.2.0 roadmap section was a list of items that
   have since shipped. All three pages updated to reflect the current


### PR DESCRIPTION
## #28 — stale test-count reference in CHANGELOG

The README badge was already migrated to a CI-driven GitHub Actions workflow shield (issue option 1), so it auto-updates. The only thing left was `CHANGELOG.md`, which still asserted *"The test-count badge advertised 216 passing; the actual count is 309"* — itself stale (the suite is now ~357) and describing a badge that no longer exists.

Rather than refresh `309` to another number that goes stale on the next test-adding PR (exactly the problem the issue calls out), the historical CHANGELOG entry is reworded to describe the static→CI-driven badge replacement:

> The hard-coded test-count badge ("216 passing", stale the moment the suite grew) was replaced with a CI-driven GitHub Actions workflow status shield that updates automatically.

Docs-only; no code touched. No remaining hard-coded "passing" counts anywhere in the repo. No CONTRIBUTING note needed since the badge is now self-updating.

Closes #28.

https://claude.ai/code/session_01DKENPtYDqmhbGbo4AcFbfZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKENPtYDqmhbGbo4AcFbfZ)_