### PR TITLE
olsson: cache Navier sin² basis in _k_bending_ssss (#56)

### DIFF
--- a/src/bvidfe/impact/olsson.py
+++ b/src/bvidfe/impact/olsson.py
@@ -33,6 +33,9 @@ from __future__ import annotations
 
 import math
 import warnings
+from functools import lru_cache
+
+import numpy as np
 
 from bvidfe.core.geometry import ImpactorGeometry, PanelGeometry
 from bvidfe.core.laminate import Laminate
@@ -59,6 +62,27 @@ _BOUNDARY_BENDING_FACTOR: dict[str, float] = {
 _CONICAL_HALF_ANGLE_DEG: float = 30.0
 
 
+@lru_cache(maxsize=64)
+def _navier_basis_ssss(
+    a: float, b: float, x0: float, y0: float, n_modes: int
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Cached SSSS Navier modal basis for a point load at ``(x0, y0)``.
+
+    Returns ``(sin2_m, sin2_n, kx, ky)`` where ``kx = m*pi/a``,
+    ``ky = n*pi/b`` and ``sin2_* = sin(k*coord)**2`` for ``m, n`` in
+    ``1..n_modes``. These depend only on panel size, impact location and
+    mode count — not on the laminate ``D`` matrix — so a parametric sweep
+    that holds geometry + location fixed (e.g. an energy sweep) reuses the
+    ``~n_modes**2`` trig evaluations instead of recomputing them per point.
+    """
+    idx = np.arange(1, n_modes + 1, dtype=float)
+    kx = idx * np.pi / a
+    ky = idx * np.pi / b
+    sin2_m = np.sin(kx * x0) ** 2
+    sin2_n = np.sin(ky * y0) ** 2
+    return sin2_m, sin2_n, kx, ky
+
+
 def _k_bending_ssss(
     lam: Laminate,
     pan: PanelGeometry,
@@ -82,18 +106,17 @@ def _k_bending_ssss(
             f"impact location ({x0}, {y0}) must lie strictly inside the panel "
             f"(0, {a}) x (0, {b}); SSSS bending compliance is singular at the boundary."
         )
-    w_over_P = 0.0
-    for m in range(1, n_modes + 1):
-        for n in range(1, n_modes + 1):
-            sin_mx = math.sin(m * math.pi * x0 / a)
-            sin_ny = math.sin(n * math.pi * y0 / b)
-            Dmn = (
-                D11 * (m * math.pi / a) ** 4
-                + 2 * (D12 + 2 * D66) * (m * math.pi / a) ** 2 * (n * math.pi / b) ** 2
-                + D22 * (n * math.pi / b) ** 4
-            )
-            w_over_P += (sin_mx * sin_ny) ** 2 / Dmn
-    w_over_P *= 4.0 / (a * b)
+    sin2_m, sin2_n, kx, ky = _navier_basis_ssss(a, b, x0, y0, n_modes)
+    kx2 = kx**2
+    ky2 = ky**2
+    # D_mn = D11*kx^4 + 2*(D12+2*D66)*kx^2*ky^2 + D22*ky^4  (outer over m, n)
+    Dmn = (
+        D11 * kx2[:, None] ** 2
+        + 2.0 * (D12 + 2.0 * D66) * kx2[:, None] * ky2[None, :]
+        + D22 * ky2[None, :] ** 2
+    )
+    numer = sin2_m[:, None] * sin2_n[None, :]
+    w_over_P = (4.0 / (a * b)) * float(np.sum(numer / Dmn))
     return 1.0 / w_over_P
 
 

--- a/tests/impact/test_olsson.py
+++ b/tests/impact/test_olsson.py
@@ -6,7 +6,13 @@ import pytest
 from bvidfe.core.geometry import ImpactorGeometry, PanelGeometry
 from bvidfe.core.laminate import Laminate
 from bvidfe.core.material import MATERIAL_LIBRARY
-from bvidfe.impact.olsson import NAVIER_N, _k_bending_ssss, onset_energy, threshold_load
+from bvidfe.impact.olsson import (
+    NAVIER_N,
+    _k_bending_ssss,
+    _navier_basis_ssss,
+    onset_energy,
+    threshold_load,
+)
 
 
 def test_threshold_load_scales_with_sqrt_G_IIc():
@@ -81,3 +87,44 @@ def test_k_bending_ssss_interior_returns_finite_positive():
     k = _k_bending_ssss(lam, pan, 75.0, 50.0)
     assert math.isfinite(k)
     assert k > 0.0
+
+
+def test_k_bending_ssss_cached_matches_scalar_navier_reference():
+    """Issue #56: the cached/vectorised Navier sum must equal the original
+    scalar double-loop implementation to machine epsilon."""
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    lam = Laminate(m, [0, 45, -45, 90] * 4, 0.152)
+    pan = PanelGeometry(150, 100)
+    x0, y0 = 70.0, 40.0
+    _, _, D = lam.abd_matrices()
+    D11, D22, D12, D66 = D[0, 0], D[1, 1], D[0, 1], D[2, 2]
+    a, b = pan.Lx_mm, pan.Ly_mm
+    w_over_P = 0.0
+    for mm in range(1, NAVIER_N + 1):
+        for nn in range(1, NAVIER_N + 1):
+            s = math.sin(mm * math.pi * x0 / a) * math.sin(nn * math.pi * y0 / b)
+            dmn = (
+                D11 * (mm * math.pi / a) ** 4
+                + 2 * (D12 + 2 * D66) * (mm * math.pi / a) ** 2 * (nn * math.pi / b) ** 2
+                + D22 * (nn * math.pi / b) ** 4
+            )
+            w_over_P += s * s / dmn
+    w_over_P *= 4.0 / (a * b)
+    reference = 1.0 / w_over_P
+    assert _k_bending_ssss(lam, pan, x0, y0) == pytest.approx(reference, rel=1e-12, abs=0.0)
+
+
+def test_navier_basis_is_cached_keyed_on_geometry_not_laminate():
+    """Issue #56: identical (a, b, x0, y0, n_modes) reuse the cached basis
+    even across different laminates — the expensive trig grid is computed once."""
+    _navier_basis_ssss.cache_clear()
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    lam_a = Laminate(m, [0, 45, -45, 90] * 4, 0.152)
+    lam_b = Laminate(m, [0, 90] * 6, 0.152)  # different D, same geometry/location
+    pan = PanelGeometry(150, 100)
+    _k_bending_ssss(lam_a, pan, 60.0, 40.0)
+    _k_bending_ssss(lam_b, pan, 60.0, 40.0)
+    _k_bending_ssss(lam_a, pan, 60.0, 40.0)
+    info = _navier_basis_ssss.cache_info()
+    assert info.misses == 1  # basis trig grid computed exactly once
+    assert info.hits >= 2  # later identical-geometry calls reuse it


### PR DESCRIPTION
## #56 — cache the Navier `sin²` basis in `_k_bending_ssss`

`_k_bending_ssss` (Olsson SSSS point-load compliance) recomputed the full `n_modes×n_modes` trig basis (`sin²(mπx₀/a)`, `sin²(nπy₀/b)`) and modal wavenumbers on **every** call. In a sweep that holds panel size + impact location fixed (e.g. an energy sweep), this is bit-identical wasted work per point.

- New `@lru_cache(maxsize=64) _navier_basis_ssss(a, b, x0, y0, n_modes)` returns `(sin2_m, sin2_n, kx, ky)` — depends only on geometry/location/mode-count, **not** the laminate `D`, so it's reused across points (and across laminates) with the same geometry.
- `_k_bending_ssss` now evaluates `D_mn` and the modal sum as a numpy outer product over the cached arrays.
- The #68 strict-interior boundary guard is preserved (still raises `ValueError` before any cached work).

## Verification

- `ruff check src tests` / `black --check src tests` — clean
- `pytest` — **319 passed, 1 xfailed** (317 baseline + 2 new tests; 0 regressions)
- **Numerical identity:** new `test_k_bending_ssss_cached_matches_scalar_navier_reference` pins the vectorised result to the original scalar double-loop Navier sum at `rel=1e-12`; the pinned `tests/validation/test_olsson_threshold_reference.py` reference values still pass unchanged.
- **Cache effectiveness:** new `test_navier_basis_is_cached_keyed_on_geometry_not_laminate` asserts the basis is computed once and reused across different laminates with identical geometry (`cache_info().misses == 1`).

Closes #56.

> Note: #55 (the sibling "warnings re-fire under sweep" issue) was investigated alongside this and is **not** included — testing revealed the shipped `"once"` filter does not actually dedupe those warnings (their messages embed per-point values, so `"once"` keyed on `(message, category, lineno)` never collapses them). That needs a real fix, not just a test; raising separately.

https://claude.ai/code/session_01DKENPtYDqmhbGbo4AcFbfZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKENPtYDqmhbGbo4AcFbfZ)_