### PR TITLE
sweep: dedupe impact warnings by category, not message (#55)

### DIFF
--- a/src/bvidfe/sweep/parametric_sweep.py
+++ b/src/bvidfe/sweep/parametric_sweep.py
@@ -27,9 +27,10 @@ from __future__ import annotations
 
 import math
 import warnings
+from contextlib import contextmanager
 from dataclasses import replace
 from pathlib import Path
-from typing import Callable, List, Optional, Sequence
+from typing import Callable, Iterator, List, Optional, Sequence
 
 import pandas as pd
 
@@ -40,11 +41,38 @@ _ProgressCallback = Callable[[int, int], None]
 _ON_ERROR_VALUES = ("raise", "skip", "warn")
 
 
-def _configure_sweep_warnings() -> None:
-    """Collapse per-iteration impact-mapping warnings to one per process so a
-    long sweep is not flooded by the same small-mass / DPA-cap diagnostic."""
-    for category in (SmallMassQuasiStaticWarning, DPACapClipWarning):
-        warnings.filterwarnings("once", category=category)
+_DEDUP_WARNING_CATEGORIES = (SmallMassQuasiStaticWarning, DPACapClipWarning)
+
+
+@contextmanager
+def _dedupe_impact_warnings() -> Iterator[None]:
+    """Emit each impact-mapping diagnostic at most once for the whole sweep.
+
+    ``impact_to_damage`` raises ``SmallMassQuasiStaticWarning`` /
+    ``DPACapClipWarning`` once per sweep point. Python's ``"once"`` /
+    ``"default"`` filter actions key on the *message text*, which here
+    embeds per-point values (the predicted DPA, the mass ratio), so the
+    filter never recognises them as duplicates and the diagnostic floods
+    stderr once per iteration. Dedupe by *category* explicitly instead.
+    Non-impact warnings (e.g. the ``on_error="warn"`` per-failure
+    ``UserWarning``) pass through unchanged.
+    """
+    seen: set[type] = set()
+    with warnings.catch_warnings():
+        outer_show = warnings.showwarning
+        # See every warning so we can decide per category; the original
+        # showwarning is still used for the first of each / pass-through.
+        warnings.simplefilter("always")
+
+        def _show(message, category, filename, lineno, file=None, line=None):
+            if issubclass(category, _DEDUP_WARNING_CATEGORIES):
+                if category in seen:
+                    return
+                seen.add(category)
+            outer_show(message, category, filename, lineno, file, line)
+
+        warnings.showwarning = _show
+        yield
 
 
 def _run_one(cfg: AnalysisConfig) -> dict:
@@ -141,19 +169,19 @@ def sweep_energies(
     """
     if base_cfg.impact is None:
         raise ValueError("sweep_energies requires base_cfg.impact to be set")
-    _configure_sweep_warnings()
     rows: List[dict] = []
     n = len(energies_J)
     # Only the impact energy (→ damage) varies here; the mesh-defining inputs
     # are constant, so build_fe_mesh reuses the cached mesh skeleton across
     # iterations and only re-derives the per-element damage factors (#23).
-    for i, E in enumerate(energies_J):
-        new_impact = replace(base_cfg.impact, energy_J=float(E))
-        cfg = replace(base_cfg, impact=new_impact)
-        row = _try_run_one(cfg, on_error, f"energy_J={float(E):g}")
-        row["energy_J"] = float(E)
-        rows.append(row)
-        _emit_progress(progress_callback, i + 1, n)
+    with _dedupe_impact_warnings():
+        for i, E in enumerate(energies_J):
+            new_impact = replace(base_cfg.impact, energy_J=float(E))
+            cfg = replace(base_cfg, impact=new_impact)
+            row = _try_run_one(cfg, on_error, f"energy_J={float(E):g}")
+            row["energy_J"] = float(E)
+            rows.append(row)
+            _emit_progress(progress_callback, i + 1, n)
     df = _finalize(rows, "energy_J")
     _write_csv(df, Path(csv_path) if csv_path else None)
     return df
@@ -168,16 +196,16 @@ def sweep_layups(
     progress_callback: Optional[_ProgressCallback] = None,
 ) -> pd.DataFrame:
     """Sweep layup sequences."""
-    _configure_sweep_warnings()
     rows: List[dict] = []
     n = len(layups)
-    for i, layup in enumerate(layups):
-        cfg = replace(base_cfg, layup_deg=list(layup))
-        layup_str = "/".join(f"{a:g}" for a in layup)
-        row = _try_run_one(cfg, on_error, f"layup={layup_str}")
-        row["layup"] = layup_str
-        rows.append(row)
-        _emit_progress(progress_callback, i + 1, n)
+    with _dedupe_impact_warnings():
+        for i, layup in enumerate(layups):
+            cfg = replace(base_cfg, layup_deg=list(layup))
+            layup_str = "/".join(f"{a:g}" for a in layup)
+            row = _try_run_one(cfg, on_error, f"layup={layup_str}")
+            row["layup"] = layup_str
+            rows.append(row)
+            _emit_progress(progress_callback, i + 1, n)
     df = _finalize(rows, "layup")
     _write_csv(df, Path(csv_path) if csv_path else None)
     return df
@@ -192,15 +220,15 @@ def sweep_thicknesses(
     progress_callback: Optional[_ProgressCallback] = None,
 ) -> pd.DataFrame:
     """Sweep ply thickness values."""
-    _configure_sweep_warnings()
     rows: List[dict] = []
     n = len(ply_thicknesses_mm)
-    for i, t in enumerate(ply_thicknesses_mm):
-        cfg = replace(base_cfg, ply_thickness_mm=float(t))
-        row = _try_run_one(cfg, on_error, f"ply_thickness_mm={float(t):g}")
-        row["ply_thickness_mm"] = float(t)
-        rows.append(row)
-        _emit_progress(progress_callback, i + 1, n)
+    with _dedupe_impact_warnings():
+        for i, t in enumerate(ply_thicknesses_mm):
+            cfg = replace(base_cfg, ply_thickness_mm=float(t))
+            row = _try_run_one(cfg, on_error, f"ply_thickness_mm={float(t):g}")
+            row["ply_thickness_mm"] = float(t)
+            rows.append(row)
+            _emit_progress(progress_callback, i + 1, n)
     df = _finalize(rows, "ply_thickness_mm")
     _write_csv(df, Path(csv_path) if csv_path else None)
     return df

--- a/tests/sweep/test_sweep.py
+++ b/tests/sweep/test_sweep.py
@@ -1,8 +1,10 @@
+import warnings
+
 import pandas as pd
 
 from bvidfe.analysis import AnalysisConfig
 from bvidfe.core.geometry import ImpactorGeometry, PanelGeometry
-from bvidfe.impact.mapping import ImpactEvent
+from bvidfe.impact.mapping import DPACapClipWarning, ImpactEvent
 from bvidfe.sweep.parametric_sweep import (
     sweep_energies,
     sweep_layups,
@@ -187,3 +189,20 @@ def test_sweep_column_schema_is_deterministic():
 
     df_t = sweep_thicknesses(cfg, ply_thicknesses_mm=[0.125, 0.152])
     assert list(df_t.columns) == ["ply_thickness_mm", *expected_results]
+
+
+def test_sweep_dedupes_dpa_cap_warning_to_once_per_sweep():
+    """Issue #55: the DPA-cap diagnostic must fire once for the whole sweep,
+    not once per point. A small panel + high energies makes every iteration
+    exceed the 80% DPA clip; each warning's message embeds the per-point DPA
+    value, so Python's 'once' filter (keyed on message text) cannot collapse
+    them — _dedupe_impact_warnings() collapses by category instead."""
+    cfg = _base_impact_cfg(panel=PanelGeometry(40, 30))
+    energies = [80.0, 100.0, 120.0, 140.0, 160.0]
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        df = sweep_energies(cfg, energies_J=energies)
+    assert len(df) == len(energies)
+    dpa_warnings = [w for w in caught if issubclass(w.category, DPACapClipWarning)]
+    # Without per-category dedup this equals len(energies) (one per point).
+    assert len(dpa_warnings) == 1


### PR DESCRIPTION
## #55 — impact-mapping warnings flood stderr once per sweep point

`impact_to_damage` raises `SmallMassQuasiStaticWarning` / `DPACapClipWarning` once per sweep point. `_configure_sweep_warnings()` tried to collapse these with `warnings.filterwarnings("once", category=...)` — but **Python's `"once"` action keys the dedup on `(message, category, lineno)`**, and these messages embed per-point values (e.g. `Olsson-predicted DPA (33279 mm^2)…`, `(41607 mm^2)…`). Every message string is unique, so `"once"` never recognised them as duplicates and a 5-point sweep still printed 5 identical-in-spirit warnings. (Verified: 5-point sweep → 5 `DPACapClipWarning` even with the old filter installed.)

### Fix

Replaced `_configure_sweep_warnings()` with a `_dedupe_impact_warnings()` context manager wrapping each sweep loop (`sweep_energies` / `sweep_layups` / `sweep_thicknesses`). It sees every warning and suppresses repeat **categories** explicitly, so each impact diagnostic fires exactly once per sweep regardless of message text. Non-impact warnings (notably the `on_error="warn"` per-failure `UserWarning`) pass through unchanged.

### Verification

- `ruff` / `black` — clean
- `pytest` — **318 passed, 1 xfailed** (317 baseline + 1 new test; 0 regressions)
- New `test_sweep_dedupes_dpa_cap_warning_to_once_per_sweep`: a 5-point DPA-clipping sweep emits exactly **1** `DPACapClipWarning` (would be 5 without the fix).
- Existing `test_sweep_energies_warn_emits_userwarning` still passes — confirms the `on_error="warn"` `UserWarning` is not swallowed by the dedup.

Closes #55.

https://claude.ai/code/session_01DKENPtYDqmhbGbo4AcFbfZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKENPtYDqmhbGbo4AcFbfZ)_