### PR TITLE
fe3d: honour panel.boundary in FPF/TAI BC set (#32)

### DIFF
--- a/src/bvidfe/analysis/bvid.py
+++ b/src/bvidfe/analysis/bvid.py
@@ -122,23 +122,9 @@ class BvidAnalysis:
                     warnings_tags.append("fe3d_buckling_artefact_dropped")
                 sigma = min(sigma_buckling, sigma_fpf) if buckling_plausible else sigma_fpf
                 buckling_eigs = [lambda_crit] if lambda_crit > 0 else None
-                fpf_governs = not buckling_plausible
             else:
                 sigma = fe3d_tai(self.config, damage, lam, sigma_0)
                 buckling_eigs = None
-                fpf_governs = True
-            # The FPF / TAI BC builder (uniaxial_x_bcs) does not yet honour
-            # cfg.panel.boundary — only the buckling path
-            # does. When the reported residual comes from FPF/TAI and a
-            # non-default boundary was requested, surface that it had no
-            # effect rather than letting it look silently applied (#32).
-            if fpf_governs and self.config.panel.boundary != "simply_supported":
-                notes.append(
-                    f"fe3d FPF/TAI: panel.boundary="
-                    f"{self.config.panel.boundary!r} is not yet applied to "
-                    f"the FPF/TAI BC set; the residual is unaffected by it."
-                )
-                warnings_tags.append("fe3d_boundary_not_applied_to_fpf_tai")
             critical_interface = None
             field_results = None
         else:

--- a/src/bvidfe/analysis/fe_tier.py
+++ b/src/bvidfe/analysis/fe_tier.py
@@ -245,7 +245,7 @@ def _solve_failure_strain_analytic(
     material = _resolve_material(cfg)
 
     # One FE solve at reference strain = strain_sign * strain_cap
-    bcs = uniaxial_x_bcs(mesh.node_coords, strain_sign * strain_cap)
+    bcs = uniaxial_x_bcs(mesh.node_coords, strain_sign * strain_cap, boundary=cfg.panel.boundary)
     u_ref = solve_linear_static(elements, mesh.element_dof_maps, mesh.n_dof, bcs)
 
     c_crit_min = np.inf
@@ -318,7 +318,7 @@ def _solve_failure_strain_analytic_scalar_ref(
     """
     material = _resolve_material(cfg)
 
-    bcs = uniaxial_x_bcs(mesh.node_coords, strain_sign * strain_cap)
+    bcs = uniaxial_x_bcs(mesh.node_coords, strain_sign * strain_cap, boundary=cfg.panel.boundary)
     u_ref = solve_linear_static(elements, mesh.element_dof_maps, mesh.n_dof, bcs)
 
     c_crit_min = np.inf

--- a/src/bvidfe/analysis/results.py
+++ b/src/bvidfe/analysis/results.py
@@ -111,9 +111,6 @@ class AnalysisResults:
     #: - ``"fe3d_buckling_artefact_dropped"`` — buckling solved but the
     #:   result was below 5% of pristine and was discarded as a numerical
     #:   artefact; residual is from first-ply failure.
-    #: - ``"fe3d_boundary_not_applied_to_fpf_tai"`` — a non-default
-    #:   ``panel.boundary`` was requested but the FPF/TAI BC set does not
-    #:   yet honour it (only the buckling path does).
     #:
     #: The ``impactor_mass_ratio_below_unity`` / ``dpa_panel_area_cap_clipped``
     #: regimes currently surface only via Python ``UserWarning`` + ``notes``;

--- a/src/bvidfe/solver/boundary.py
+++ b/src/bvidfe/solver/boundary.py
@@ -2,8 +2,9 @@
 
 Standard patterns:
 - uniaxial_x_bcs: clamp x_min, prescribe u_x at x_max (+ symmetry on y_min,
-  z_min). The sign of ``applied_strain`` selects compression (negative) or
-  tension (positive) — the BC topology is identical either way.
+  z_min) plus a ``boundary``-dependent u_z edge restraint. The sign of
+  ``applied_strain`` selects compression (negative) or tension (positive)
+  — the in-plane BC topology is identical either way.
 - apply_dirichlet_penalty: multiply K[i,i] by penalty and F[i] = penalty * value.
 """
 
@@ -62,7 +63,11 @@ def _nodes_on_plane(
     return np.where(np.abs(node_coords[:, axis] - coord) < tol)[0]
 
 
-def uniaxial_x_bcs(node_coords: np.ndarray, applied_strain: float) -> List[BoundaryCondition]:
+def uniaxial_x_bcs(
+    node_coords: np.ndarray,
+    applied_strain: float,
+    boundary: str = "simply_supported",
+) -> List[BoundaryCondition]:
     """Build BCs for a uniaxial test along x (compression or tension).
 
     The sign of ``applied_strain`` is the only difference between the
@@ -74,6 +79,17 @@ def uniaxial_x_bcs(node_coords: np.ndarray, applied_strain: float) -> List[Bound
       positive = tension)
     - y_min nodes: u_y = 0 (symmetry)
     - z_min nodes: u_z = 0 (symmetry)
+
+    ``boundary`` adds the same panel-edge out-of-plane (u_z) restraint the
+    fe3d buckling path applies, so the GUI boundary selector has a visible
+    effect on the FPF/TAI residual (#32):
+
+    - ``"simply_supported"`` : pin u_z on the two loaded edges (x_min, x_max)
+    - ``"clamped"``          : pin u_z on all four lateral edges
+    - ``"free"``             : no extra edge restraint
+
+    An unrecognised value is treated as ``"simply_supported"`` (matching the
+    fe3d buckling path's fallback).
     """
     Lx = node_coords[:, 0].max() - node_coords[:, 0].min()
     xmin_nodes = _nodes_on_plane(node_coords, 0, node_coords[:, 0].min())
@@ -90,4 +106,15 @@ def uniaxial_x_bcs(node_coords: np.ndarray, applied_strain: float) -> List[Bound
         bcs.append(BoundaryCondition(dof=3 * int(n) + 1, value=0.0))
     for n in zmin_nodes:
         bcs.append(BoundaryCondition(dof=3 * int(n) + 2, value=0.0))
+
+    if boundary != "free":
+        edge_nodes: set[int] = set()
+        edge_nodes.update(int(n) for n in xmin_nodes)
+        edge_nodes.update(int(n) for n in xmax_nodes)
+        if boundary == "clamped":
+            ymax_nodes = _nodes_on_plane(node_coords, 1, node_coords[:, 1].max())
+            edge_nodes.update(int(n) for n in ymin_nodes)
+            edge_nodes.update(int(n) for n in ymax_nodes)
+        for n in sorted(edge_nodes):
+            bcs.append(BoundaryCondition(dof=3 * n + 2, value=0.0))
     return bcs

--- a/tests/analysis/test_fpf_strain_solve_equivalence.py
+++ b/tests/analysis/test_fpf_strain_solve_equivalence.py
@@ -21,6 +21,8 @@ second.
 
 from __future__ import annotations
 
+import dataclasses
+
 import numpy as np
 import pytest
 
@@ -106,3 +108,34 @@ def test_vectorised_tension_path_also_matches_scalar_reference():
     )
     assert np.isfinite(eps_vec) and np.isfinite(eps_ref)
     assert eps_vec == pytest.approx(eps_ref, rel=1e-10, abs=1e-12)
+
+
+def test_panel_boundary_changes_fpf_strain():
+    """Issue #32: the FPF/TAI BC builder must honour ``panel.boundary``.
+
+    Previously uniaxial_x_bcs ignored it, so the fe3d FPF/TAI residual was
+    identical for clamped/simply_supported/free (silent no-op). Now the same
+    u_z edge restraint the buckling path uses is applied, so the three
+    boundary conditions must give measurably different — and physically
+    ordered — failure strains: more out-of-plane edge restraint (clamped)
+    is stiffer and fails sooner than the unrestrained (free) case.
+    """
+    damage = DamageState(delaminations=[], dent_depth_mm=0.0)
+    cfg, mesh, elements = _build_setup(damage)
+
+    def eps_for(boundary: str) -> float:
+        panel = dataclasses.replace(cfg.panel, boundary=boundary)
+        cfg_b = dataclasses.replace(cfg, panel=panel)
+        return _solve_failure_strain_analytic(
+            cfg_b, mesh, elements, strain_sign=-1, criterion="larc05"
+        )
+
+    eps_ss = eps_for("simply_supported")
+    eps_cl = eps_for("clamped")
+    eps_fr = eps_for("free")
+
+    assert eps_cl != eps_ss
+    assert eps_fr != eps_ss
+    # Monotone: clamped (most u_z edge restraint) < simply_supported
+    #           < free (no extra restraint).
+    assert eps_cl < eps_ss < eps_fr, (eps_cl, eps_ss, eps_fr)

--- a/tests/solver/test_boundary.py
+++ b/tests/solver/test_boundary.py
@@ -59,3 +59,28 @@ def test_uniaxial_x_bcs_tension_positive_displacement():
     bcs = uniaxial_x_bcs(node_coords, applied_strain=0.005)
     xmax = [b for b in bcs if abs(b.value - (0.005 * 2)) < 1e-6]
     assert len(xmax) == 4
+
+
+def _uz_constrained_nodes(bcs):
+    """Set of node indices with a u_z=0 constraint (dof % 3 == 2, value 0)."""
+    return {b.dof // 3 for b in bcs if b.dof % 3 == 2 and b.value == 0.0}
+
+
+def test_uniaxial_x_bcs_boundary_adds_nested_uz_edge_restraints():
+    """Issue #32: panel.boundary adds the same u_z edge restraint the fe3d
+    buckling path uses. On a 3x3x3 grid the constrained-u_z node sets must
+    nest strictly free ⊂ simply_supported ⊂ clamped (free = z_min symmetry
+    only; simply_supported adds the two loaded x-edges; clamped adds the
+    y-edges too)."""
+    coords = np.array(
+        [[x, y, z] for x in (0.0, 1.0, 2.0) for y in (0.0, 1.0, 2.0) for z in (0.0, 1.0, 2.0)],
+        dtype=float,
+    )
+    free = _uz_constrained_nodes(uniaxial_x_bcs(coords, -0.01, boundary="free"))
+    ss = _uz_constrained_nodes(uniaxial_x_bcs(coords, -0.01, boundary="simply_supported"))
+    clamped = _uz_constrained_nodes(uniaxial_x_bcs(coords, -0.01, boundary="clamped"))
+    assert free < ss < clamped  # strict subset chain
+    # free is exactly the z_min symmetry face (9 of the 27 nodes).
+    assert free == {i for i, c in enumerate(coords) if c[2] == 0.0}
+    # An unrecognised value falls back to simply_supported (mirrors buckling).
+    assert _uz_constrained_nodes(uniaxial_x_bcs(coords, -0.01, boundary="bogus")) == ss


### PR DESCRIPTION
## #32 — fe3d FPF/TAI silently ignored `panel.boundary`

`uniaxial_x_bcs` built a fixed clamp-x_min + y/z symmetry set with **no boundary awareness**, so the fe3d FPF/TAI residual was identical for `clamped` / `simply_supported` / `free`. Only the buckling path honoured the GUI selector — and when the buckling-plausibility gate fell back to FPF, toggling the boundary changed nothing.

### Fix (chosen approach: mirror the buckling path exactly)

- **`solver/boundary.py`** — `uniaxial_x_bcs` gains a `boundary` parameter that adds the same out-of-plane (`u_z`) edge restraint `fe3d_cai_buckling` uses:
  - `simply_supported` → pin `u_z` on the two loaded edges (x_min, x_max)
  - `clamped` → pin `u_z` on all four lateral edges
  - `free` → no extra edge restraint
  - unrecognised → treated as `simply_supported` (matches the buckling path's fallback)
- **`analysis/fe_tier.py`** — thread `cfg.panel.boundary` into both `_solve_failure_strain_analytic` **and** its scalar-reference twin (so the vec/scalar equivalence test stays valid — both share `cfg`).
- **`analysis/bvid.py`** + **`analysis/results.py`** — the "boundary not applied to FPF/TAI" safety-net note and the `fe3d_boundary_not_applied_to_fpf_tai` structured tag (and its docstring entry) are now false and removed; the unused `fpf_governs` bookkeeping went with them.

### Why no pinned-number regressions

The project default is `simply_supported`, so the default fe3d FPF/TAI residual does shift — but only sub-1%, which is within every existing fe3d test's tolerance band, and the vec/scalar equivalence test compares the two paths to *each other* (both now get the same boundary), so it still holds. Full suite stayed green with no re-baselining needed.

### Verification

- `ruff` / `black` — clean
- `pytest` — **322 passed, 1 xfailed** (320 baseline + 2 new tests; 0 regressions)
- `test_panel_boundary_changes_fpf_strain`: FPF strain is now measurably and **physically ordered** `clamped (0.009533) < simply_supported (0.009545) < free (0.009584)` — more `u_z` edge restraint ⇒ stiffer ⇒ fails sooner.
- `test_uniaxial_x_bcs_boundary_adds_nested_uz_edge_restraints`: builder-level proof the constrained-`u_z` node sets nest strictly `free ⊂ simply_supported ⊂ clamped`, plus the unrecognised→simply_supported fallback.

Closes #32.

https://claude.ai/code/session_01DKENPtYDqmhbGbo4AcFbfZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKENPtYDqmhbGbo4AcFbfZ)_