### PR TITLE
ci: bump actions/setup-python from 5 to 6 (supersedes #7)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install -e ".[dev]"
@@ -22,7 +22,7 @@ jobs:
     needs: test
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - run: pip install -e ".[dev]"


### PR DESCRIPTION
Bumps `actions/setup-python` from v5 to v6 on both jobs in `.github/workflows/tests.yml`.

Equivalent to dependabot **#7**, applied directly because #7's stale base conflicted with the `actions/checkout@v6` bump (#10) that just merged on the same file. Superseding #7.

- 1 file, +2/−2 (both `setup-python@v5` → `@v6`).
- `actions/setup-python@v6` requires Actions runner ≥ v2.327.1 — GitHub-hosted runners are well past that.

Once this lands, #7 is redundant (will be closed as superseded).

https://claude.ai/code/session_01DKENPtYDqmhbGbo4AcFbfZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKENPtYDqmhbGbo4AcFbfZ)_