### PR TITLE
Fix sublaminate buckling load calculation and memory efficiency

### DIFF
--- a/.claude/hooks/session_start.sh
+++ b/.claude/hooks/session_start.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# SessionStart hook for Claude Code.
+#
+# Reports any black formatting drift and ruff lint issues so the main Claude
+# agent sees them in its initial context and can fix them before delegating
+# to subagents (which historically commit without running formatters).
+#
+# This hook is informational only: it always exits 0 and never blocks the
+# session.
+
+set -u
+# Intentionally not using -e: we want to keep running even if one of the
+# checks reports failures, and we always want to exit 0.
+
+REPO_ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+cd "$REPO_ROOT" || exit 0
+
+# Only check directories that exist (keeps the hook safe on partial clones).
+TARGETS=()
+[ -d src ] && TARGETS+=("src")
+[ -d tests ] && TARGETS+=("tests")
+
+if [ "${#TARGETS[@]}" -eq 0 ]; then
+    echo "[session-start] No src/ or tests/ directory found; skipping formatter checks."
+    exit 0
+fi
+
+echo "[session-start] Running formatter/linter drift checks on: ${TARGETS[*]}"
+echo
+
+# ---- black --------------------------------------------------------------
+if command -v black >/dev/null 2>&1; then
+    black --check --quiet "${TARGETS[@]}" >/dev/null 2>&1
+    BLACK_RC=$?
+    if [ $BLACK_RC -eq 0 ]; then
+        echo "[session-start] black: clean (no formatting drift)."
+    else
+        # Re-run without --quiet to capture the "would reformat" lines for the agent.
+        DRIFT="$(black --check "${TARGETS[@]}" 2>&1 | grep -E '^would reformat' | sed 's/^would reformat //')"
+        echo "[session-start] black: FORMATTING DRIFT DETECTED"
+        if [ -n "$DRIFT" ]; then
+            echo "  Files needing reformatting:"
+            while IFS= read -r f; do
+                [ -n "$f" ] && echo "    - $f"
+            done <<< "$DRIFT"
+        fi
+        echo "  Action: run \`black src tests\` before committing."
+        echo "  (CI runs \`black --check src tests\` and will fail until this is fixed.)"
+    fi
+else
+    echo "[session-start] black: not installed (run \`pip install -e .[dev]\` to enable this check)."
+fi
+
+echo
+
+# ---- ruff ---------------------------------------------------------------
+if command -v ruff >/dev/null 2>&1; then
+    RUFF_OUT="$(ruff check "${TARGETS[@]}" 2>&1)"
+    RUFF_RC=$?
+    if [ $RUFF_RC -eq 0 ]; then
+        echo "[session-start] ruff: clean (no lint issues)."
+    else
+        echo "[session-start] ruff: LINT ISSUES DETECTED"
+        # Indent ruff output for readability in the agent context.
+        echo "$RUFF_OUT" | sed 's/^/  /'
+        echo "  Action: run \`ruff check --fix src tests\` (or fix manually) before committing."
+    fi
+else
+    echo "[session-start] ruff: not installed (run \`pip install -e .[dev]\` to enable this check)."
+fi
+
+# Always succeed: this hook is informational, not a hard gate.
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session_start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10", "3.11", "3.12"]

--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,11 @@ docs/superpowers/
 CLAUDE.md
 .claude/
 .anthropic/
+
+# Shared Claude Code config: track the SessionStart hook and its settings so
+# all sessions (web and local) pick up the same formatter-drift check.
+!.claude/
+.claude/*
+!.claude/settings.json
+!.claude/hooks/
+!.claude/hooks/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+# Pre-commit hooks for BVID-FE
+# Install: pip install pre-commit && pre-commit install
+# Run manually: pre-commit run --all-files
+#
+# Hook versions are pinned to match the version constraints in
+# pyproject.toml [project.optional-dependencies] dev.
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.10
+    hooks:
+      - id: ruff

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,14 +41,19 @@ pytest tests/analysis/ -v
 ## Code Style
 
 - Format with **black** and lint with **ruff** (pre-commit hooks enforce both)
-- Install pre-commit hooks once after cloning:
-  ```bash
-  pip install pre-commit
-  pre-commit install
-  ```
 - Add docstrings to all public functions and classes
 - Include units in variable names and docstrings (MPa, mm, rad, J)
 - Use SI units throughout (millimetres, MPa, kg)
+
+## Pre-commit setup
+
+Install pre-commit hooks once after cloning so black, ruff, and basic file
+hygiene checks run automatically before each commit:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
 
 ## Pull Requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,15 @@ Create a new file in `src/bvidfe/failure/` subclassing `FailureCriterion` from `
 3. Add the dispatch branch in `BvidAnalysis.run()` (`analysis/bvid.py`)
 4. Add end-to-end tests in `tests/analysis/test_my_tier_path.py`
 
+## Claude Code on the web
+
+This repo ships a `SessionStart` hook at `.claude/hooks/session_start.sh` (wired
+up via `.claude/settings.json`) that runs `black --check src tests` and
+`ruff check src tests` at the start of every Claude Code session and reports
+any drift. It is informational only (always exits 0) and prevents agents from
+delegating commits while formatting is broken. If `black`/`ruff` are not
+installed yet, the hook prints a friendly note and exits cleanly.
+
 ## Code of Conduct
 
 Be respectful. Focus feedback on code and ideas, not people. Contributions at any experience level are welcome.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,19 @@ pip install pre-commit
 pre-commit install
 ```
 
+### Before committing
+
+If you haven't installed pre-commit, run these three commands locally before
+pushing — CI runs `black --check` and **will fail** if any file is not
+already formatted, so you must auto-format with `black` (not just verify
+with `black --check`):
+
+```bash
+ruff check src tests
+black src tests        # auto-format in place; do NOT use --check here
+pytest -q
+```
+
 ## Pull Requests
 
 1. Fork the repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=7,<9", "ruff>=0.5,<1", "black>=24,<26"]
+dev = ["pytest>=7,<9", "ruff>=0.5,<1", "black>=24,<26", "pre-commit>=3,<5"]
 
 [project.urls]
 Homepage = "https://github.com/ranipdx-glitch/BVID-FE"

--- a/src/bvidfe/analysis/fe_tier.py
+++ b/src/bvidfe/analysis/fe_tier.py
@@ -13,7 +13,6 @@ import time
 from typing import List
 
 import numpy as np
-import scipy.sparse as sp
 
 from bvidfe.analysis.config import AnalysisConfig
 from bvidfe.analysis.fe_mesh import FeMesh, build_fe_mesh, estimate_fe_mesh_size
@@ -22,7 +21,7 @@ from bvidfe.damage.state import DamageState
 from bvidfe.elements.hex8 import Hex8Element, build_geometry_table
 from bvidfe.failure.larc05 import larc05_index, larc05_index_batch
 from bvidfe.failure.tsai_wu import tsai_wu_index, tsai_wu_index_batch
-from bvidfe.solver.assembler import assemble_global_stiffness
+from bvidfe.solver.assembler import assemble_coo, assemble_global_stiffness
 from bvidfe.solver.boundary import (
     BoundaryCondition,
     apply_dirichlet_penalty,
@@ -440,24 +439,18 @@ def fe3d_cai_buckling(
     # because the plies remain intact; only fiber-break-core elements carry less.
     sigma_bar_ref = np.zeros((3, 3))
     sigma_bar_ref[0, 0] = sigma_ref_MPa
+    in_plane_factors = mesh.in_plane_damage_factors
 
-    # Vectorised COO assembly of K_g (same pattern as assembler.py)
-    rows_chunks: list[np.ndarray] = []
-    cols_chunks: list[np.ndarray] = []
-    data_chunks: list[np.ndarray] = []
-    for eidx, elem in enumerate(elements):
-        damage_f = float(mesh.in_plane_damage_factors[eidx])
-        sigma_elem = sigma_bar_ref * damage_f
-        Kg_e = elem.geometric_stiffness_matrix(sigma_elem)
-        dof_arr = np.asarray(mesh.element_dof_maps[eidx], dtype=np.int64)
-        rows_chunks.append(np.broadcast_to(dof_arr[:, None], (24, 24)).ravel())
-        cols_chunks.append(np.broadcast_to(dof_arr[None, :], (24, 24)).ravel())
-        data_chunks.append(Kg_e.ravel())
-    rows = np.concatenate(rows_chunks) if rows_chunks else np.array([], dtype=np.int64)
-    cols = np.concatenate(cols_chunks) if cols_chunks else np.array([], dtype=np.int64)
-    data = np.concatenate(data_chunks) if data_chunks else np.array([], dtype=float)
+    def _kg(e_idx: int) -> np.ndarray:
+        return elements[e_idx].geometric_stiffness_matrix(
+            sigma_bar_ref * float(in_plane_factors[e_idx])
+        )
 
-    Kg = sp.coo_matrix((data, (rows, cols)), shape=(K.shape[0], K.shape[0])).tocsc()
+    # Share the COO assembler with assemble_global_stiffness so the two
+    # build paths cannot drift, and re-use its pre-allocated buffers
+    # (issue #33: the old list-of-chunks build doubled peak memory near
+    # the FE3D_MAX_DOF cap and SIGKILLed on 16 GB workstations).
+    Kg = assemble_coo(mesh.element_dof_maps, mesh.n_dof, _kg)
     _t("Kg assembled", t0)
 
     # Apply penalty BCs to K (not Kg) — rigid-body suppression plus
@@ -498,6 +491,10 @@ def fe3d_cai_buckling(
             bcs.append(BoundaryCondition(dof=3 * int(node_idx) + 2, value=0.0))
     F_dummy = np.zeros(n_dof)
     K_mod, _ = apply_dirichlet_penalty(K, F_dummy, bcs, penalty=1.0e10)
+    # apply_dirichlet_penalty returns a fresh CSC matrix; the un-penalised K
+    # is not used downstream. Drop it so its memory is freed before the
+    # eigensolver allocates ARPACK workspaces (issue #33).
+    del K
 
     # Solve generalised eigenproblem K phi = lambda K_g phi for smallest positive eig.
     try:

--- a/src/bvidfe/analysis/semi_analytical.py
+++ b/src/bvidfe/analysis/semi_analytical.py
@@ -108,11 +108,11 @@ def sublaminate_buckling_load(
     same convention as the Navier impact-compliance solver in
     ``impact/olsson.py`` which passes ``pan.Lx_mm``, ``pan.Ly_mm`` directly.)
 
-    The selected sublaminate is the *thinner* of the "above" and "below"
-    stacks at the interface (it buckles first), and a boundary-dependent
-    multiplier is applied so the parent panel's edge condition transmits
-    appropriate lateral restraint to the sublaminate (clamped: 1.9x,
-    free: 0.5x, simply-supported: 1.0x).
+    The selected sublaminate is the *thinner* (by through-thickness, not
+    ply count) of the "above" and "below" stacks at the interface (it
+    buckles first), and a boundary-dependent multiplier is applied so the
+    parent panel's edge condition transmits appropriate lateral restraint
+    to the sublaminate (clamped: 1.9x, free: 0.5x, simply-supported: 1.0x).
 
     Parameters
     ----------
@@ -145,20 +145,28 @@ def sublaminate_buckling_load(
     """
     i = ellipse.interface_index
     full_layup = lam.layup_deg
+    full_thicknesses = lam.ply_thicknesses_mm
 
-    # Choose the thinner sublaminate between "above" (plies 0..i) and "below" (plies i+1..)
+    # Choose the geometrically thinner sublaminate between "above" (plies
+    # 0..i) and "below" (plies i+1..). Selection is by through-thickness
+    # (sum of per-ply thicknesses), not ply count — for non-uniform
+    # laminates the side with fewer plies may be the geometrically thicker
+    # one, and the *thinner* stack is what buckles first.
     upper_layup = full_layup[: i + 1]
     lower_layup = full_layup[i + 1 :]
-    sub_layup = upper_layup if len(upper_layup) <= len(lower_layup) else lower_layup
+    upper_thicknesses = full_thicknesses[: i + 1]
+    lower_thicknesses = full_thicknesses[i + 1 :]
+    upper_t_total = sum(upper_thicknesses)
+    lower_t_total = sum(lower_thicknesses)
+    if upper_t_total <= lower_t_total:
+        sub_layup = upper_layup
+        sub_thicknesses = upper_thicknesses
+    else:
+        sub_layup = lower_layup
+        sub_thicknesses = lower_thicknesses
     if len(sub_layup) == 0:
         return float("inf")
 
-    full_thicknesses = lam.ply_thicknesses_mm
-    upper_thicknesses = full_thicknesses[: i + 1]
-    lower_thicknesses = full_thicknesses[i + 1 :]
-    sub_thicknesses = (
-        upper_thicknesses if len(upper_layup) <= len(lower_layup) else lower_thicknesses
-    )
     D = _sublaminate_D_matrix(lam.material, sub_layup, sub_thicknesses)
     D11, D22, D12, D66 = D[0, 0], D[1, 1], D[0, 1], D[2, 2]
 
@@ -289,10 +297,15 @@ def semi_analytical_cai(
 
     # Sublaminate thickness — sum the actual per-ply thicknesses of whichever
     # half ("above" or "below" the interface) is the buckling sublaminate.
+    # Selection is by through-thickness (not ply count) so that for
+    # non-uniform laminates the geometrically thinner stack is picked —
+    # this must match the selection in ``sublaminate_buckling_load``.
     thicknesses = lam.ply_thicknesses_mm
     upper_t = thicknesses[: crit_idx + 1]
     lower_t = thicknesses[crit_idx + 1 :]
-    sub_t = upper_t if len(upper_t) <= len(lower_t) else lower_t
+    upper_t_total = sum(upper_t)
+    lower_t_total = sum(lower_t)
+    sub_t = upper_t if upper_t_total <= lower_t_total else lower_t
     if len(sub_t) == 0:
         return sigma_soutis, crit_idx, None
     h_sub = float(sum(sub_t))

--- a/src/bvidfe/analysis/semi_analytical.py
+++ b/src/bvidfe/analysis/semi_analytical.py
@@ -1,9 +1,12 @@
 """Semi-analytical tier: sublaminate Rayleigh-Ritz buckling + critical interface scoring.
 
 The ellipse is approximated as its enclosing simply-supported rectangle
-(2a x 2b in the panel frame). For orthotropic simply-supported rectangles
-under uniaxial compression, the sine basis is exact and the eigenvalue is
-closed-form — we minimize over integer modes (m, n) in [1..5] x [1..5].
+with full side lengths (2 * major_mm) x (2 * minor_mm) in the panel
+frame. For orthotropic simply-supported rectangles under uniaxial
+compression, the sine basis is exact and the eigenvalue is closed-form —
+we minimize over integer modes (m, n) in [1..5] x [1..5]. The closed-
+form formula uses the FULL side lengths (a, b) as in Timoshenko & Gere
+§9.2 / Reddy 4.4.4, NOT the ellipse semi-axes.
 
 Sublaminate selection: the plies above the delaminated interface form the
 thinner buckling sublaminate (closer to the impact face for interfaces in
@@ -82,22 +85,28 @@ def sublaminate_buckling_load(
     above the given delamination interface.
 
     The delaminated sublaminate is approximated as an orthotropic
-    simply-supported rectangle with semi-axes equal to the ellipse's major
-    and minor axes (the enclosing-rectangle simplification). Under uniaxial
-    compression along x, the closed-form Rayleigh-Ritz solution with a
-    sine-basis trial function (Timoshenko & Gere §9.2; Reddy *Theory and
-    Analysis of Elastic Plates*, Eq. 4.4.4) is
+    simply-supported rectangle whose full side lengths equal twice the
+    ellipse's semi-axes (the enclosing-rectangle simplification:
+    ``a = 2 * major_mm``, ``b = 2 * minor_mm``). Under uniaxial compression
+    along x, the closed-form Navier / Rayleigh-Ritz solution with a sine-
+    basis trial function ``sin(m*pi*x/a) * sin(n*pi*y/b)`` on the domain
+    ``0 <= x <= a``, ``0 <= y <= b`` (Timoshenko & Gere §9.2; Reddy *Theory
+    and Analysis of Elastic Plates*, Eq. 4.4.4) is
 
         N_cr(m, n) = (pi^2 / a^2)
                      * [D11 * m^4 + 2*(D12 + 2*D66)*(m*a/b)^2 * n^2
                         + D22 * (a*n/b)^4]
                      / m^2
 
-    where (a, b) are the rectangle semi-axes, (m, n) are the integer half-
-    wave numbers along x and y, and the D_ij are the sublaminate's CLT
-    bending stiffnesses. We minimise over (m, n) in [1..5] x [1..5]; the
-    range is bounded by the typical 1-3 mode of practical delaminations
-    plus a safety margin.
+    where (a, b) are the **full** rectangle side lengths (NOT semi-axes),
+    (m, n) are the integer half-wave numbers along x and y, and the D_ij
+    are the sublaminate's CLT bending stiffnesses. We minimise over (m, n)
+    in [1..5] x [1..5]; the range is bounded by the typical 1-3 mode of
+    practical delaminations plus a safety margin. (Note: the sine basis
+    above vanishes at x=0, x=a, y=0, y=b, so a/b here must be the full
+    plate dimensions for the SSSS boundary conditions to be satisfied —
+    same convention as the Navier impact-compliance solver in
+    ``impact/olsson.py`` which passes ``pan.Lx_mm``, ``pan.Ly_mm`` directly.)
 
     The selected sublaminate is the *thinner* of the "above" and "below"
     stacks at the interface (it buckles first), and a boundary-dependent
@@ -111,8 +120,11 @@ def sublaminate_buckling_load(
         Full panel laminate; supplies material, layup, and ply thickness.
     ellipse : DelaminationEllipse
         Delamination at which the sublaminate forms. Its
-        ``interface_index`` selects the sublaminate thickness; ``major_mm``
-        and ``minor_mm`` are the rectangle semi-axes.
+        ``interface_index`` selects the sublaminate thickness; the
+        enclosing rectangle has full side lengths
+        ``a = 2 * ellipse.major_mm`` and ``b = 2 * ellipse.minor_mm``
+        (``major_mm`` / ``minor_mm`` are the ellipse semi-axes, per
+        ``DelaminationEllipse.area_mm2 = pi * major * minor``).
     boundary : str
         One of ``"simply_supported"``, ``"clamped"``, ``"free"``.
 
@@ -150,9 +162,15 @@ def sublaminate_buckling_load(
     D = _sublaminate_D_matrix(lam.material, sub_layup, sub_thicknesses)
     D11, D22, D12, D66 = D[0, 0], D[1, 1], D[0, 1], D[2, 2]
 
-    # Rectangle dimensions (panel frame). Ellipse semi-axes = a, b.
-    a = ellipse.major_mm
-    b = ellipse.minor_mm
+    # Rectangle dimensions (panel frame). The Navier sine basis
+    # sin(m*pi*x/a) * sin(n*pi*y/b) used in the closed-form eigenvalue
+    # vanishes at x=0,a and y=0,b, so (a, b) must be the FULL rectangle
+    # side lengths — i.e. twice the ellipse semi-axes — for the SSSS
+    # boundary conditions to be satisfied. (Issue #29: previously assigned
+    # a = ellipse.major_mm directly, which used semi-axes and overpredicted
+    # N_cr by ~4x because N_cr ∝ 1/a^2.)
+    a = 2.0 * ellipse.major_mm
+    b = 2.0 * ellipse.minor_mm
     if a <= 0 or b <= 0:
         return float("inf")
 

--- a/src/bvidfe/solver/assembler.py
+++ b/src/bvidfe/solver/assembler.py
@@ -2,10 +2,72 @@
 
 from __future__ import annotations
 
-from typing import Sequence
+from typing import Callable, Sequence
 
 import numpy as np
 import scipy.sparse as sp
+
+
+def assemble_coo(
+    element_dof_maps: Sequence[np.ndarray],
+    n_dof: int,
+    matrix_fn: Callable[[int], np.ndarray],
+) -> sp.csc_matrix:
+    """Assemble a global sparse matrix from per-element 24x24 contributions.
+
+    Shared core for both the elastic stiffness (``assemble_global_stiffness``)
+    and the geometric stiffness (assembled inline by the buckling path in
+    ``analysis.fe_tier``). The two had drifted into independent
+    list-of-chunks COO assemblers; this helper centralises the COO build.
+
+    Memory: row/col/data buffers are pre-allocated as a single contiguous
+    ``np.empty(n_elem * 576)`` each rather than appended-and-concatenated
+    per element. On a problem at the documented ``FE3D_MAX_DOF`` cap
+    (~166k elements) this halves the transient memory held alive before
+    ``coo_matrix.tocsc()`` — issue #33.
+
+    Parameters
+    ----------
+    element_dof_maps : sequence of int arrays, each length 24, giving the
+        global DOF index for each of the 24 element DOFs.
+    n_dof : total number of global DOFs.
+    matrix_fn : callable ``(e_idx) -> (24, 24) ndarray`` returning the per-
+        element contribution. Indexed by element position in
+        ``element_dof_maps``.
+
+    Returns
+    -------
+    scipy.sparse.csc_matrix of shape ``(n_dof, n_dof)``.
+    """
+    n_elem = len(element_dof_maps)
+    if n_elem == 0:
+        return sp.csc_matrix((n_dof, n_dof))
+
+    # 24 * 24 = 576 entries per element. One pre-allocated contiguous
+    # buffer per array — no list-of-chunks overhead, no concatenate copy.
+    block = 576
+    total = n_elem * block
+    rows = np.empty(total, dtype=np.int32)
+    cols = np.empty(total, dtype=np.int32)
+    data = np.empty(total, dtype=np.float64)
+
+    for e_idx, dof_map in enumerate(element_dof_maps):
+        dof_arr = np.asarray(dof_map, dtype=np.int32)
+        if dof_arr.shape != (24,):
+            raise ValueError(f"dof_map must have 24 entries, got {len(dof_map)}")
+        Ke = matrix_fn(e_idx)
+        if Ke.shape != (24, 24):
+            raise ValueError(f"element matrix must be (24,24), got {Ke.shape}")
+        start = e_idx * block
+        end = start + block
+        # Outer product of dof indices → 24x24 row/col index arrays, written
+        # directly into the pre-allocated slice (no temporary lists).
+        rows[start:end] = np.broadcast_to(dof_arr[:, None], (24, 24)).ravel()
+        cols[start:end] = np.broadcast_to(dof_arr[None, :], (24, 24)).ravel()
+        data[start:end] = Ke.ravel()
+
+    K = sp.coo_matrix((data, (rows, cols)), shape=(n_dof, n_dof))
+    return K.tocsc()
 
 
 def assemble_global_stiffness(
@@ -13,46 +75,28 @@ def assemble_global_stiffness(
     element_dof_maps: Sequence[np.ndarray],
     n_dof: int,
 ) -> sp.csc_matrix:
-    """Assemble the global stiffness matrix in CSC format.
+    """Assemble the global elastic stiffness matrix in CSC format.
+
+    Thin wrapper around :func:`assemble_coo` preserved for backwards
+    compatibility — call sites that already exist (``solver.static``,
+    ``analysis.fe_tier``, and the test suite) continue to work
+    unchanged.
 
     Parameters
     ----------
-    elements : sequence of elements each exposing `.stiffness_matrix() -> (24, 24)`
-    element_dof_maps : sequence of int arrays, each length 24, giving the global DOF
-        index for each of the 24 element DOFs.
+    elements : sequence of elements each exposing
+        ``.stiffness_matrix() -> (24, 24)``.
+    element_dof_maps : sequence of int arrays, each length 24.
     n_dof : total number of global DOFs.
     """
     if len(elements) != len(element_dof_maps):
         raise ValueError(
-            f"elements (n={len(elements)}) and element_dof_maps (n={len(element_dof_maps)}) length mismatch"
+            f"elements (n={len(elements)}) and element_dof_maps "
+            f"(n={len(element_dof_maps)}) length mismatch"
         )
+    elements_seq = elements
 
-    # Vectorized COO assembly: one numpy meshgrid per element instead of
-    # a 24x24 Python loop. ~10x faster on large meshes (the inner Python
-    # overhead was the dominant cost on 4k+ element meshes).
-    n_elem = len(elements)
-    rows_chunks: list[np.ndarray] = []
-    cols_chunks: list[np.ndarray] = []
-    data_chunks: list[np.ndarray] = []
+    def _ke(e_idx: int) -> np.ndarray:
+        return elements_seq[e_idx].stiffness_matrix()
 
-    for elem, dof_map in zip(elements, element_dof_maps):
-        Ke = elem.stiffness_matrix()
-        if Ke.shape != (24, 24):
-            raise ValueError(f"element stiffness must be (24,24), got {Ke.shape}")
-        dof_arr = np.asarray(dof_map, dtype=np.int64)
-        if dof_arr.shape != (24,):
-            raise ValueError(f"dof_map must have 24 entries, got {len(dof_map)}")
-        # Outer product of dof indices → 24x24 row/col index arrays
-        rows_chunks.append(np.broadcast_to(dof_arr[:, None], (24, 24)).ravel())
-        cols_chunks.append(np.broadcast_to(dof_arr[None, :], (24, 24)).ravel())
-        data_chunks.append(Ke.ravel())
-
-    if n_elem == 0:
-        return sp.csc_matrix((n_dof, n_dof))
-
-    rows = np.concatenate(rows_chunks)
-    cols = np.concatenate(cols_chunks)
-    data = np.concatenate(data_chunks)
-
-    K = sp.coo_matrix((data, (rows, cols)), shape=(n_dof, n_dof))
-    return K.tocsc()
+    return assemble_coo(element_dof_maps, n_dof, _ke)

--- a/tests/analysis/test_semi_analytical.py
+++ b/tests/analysis/test_semi_analytical.py
@@ -159,8 +159,11 @@ def test_buckling_load_matches_closed_form_ssss_square():
     # which makes m=n=1 the analytic minimizer for any D with D11 == D22.
     semi = 25.0  # mm
     ell = DelaminationEllipse(
-        interface_index=1, centroid_mm=(0.0, 0.0),
-        major_mm=semi, minor_mm=semi, orientation_deg=0.0,
+        interface_index=1,
+        centroid_mm=(0.0, 0.0),
+        major_mm=semi,
+        minor_mm=semi,
+        orientation_deg=0.0,
     )
 
     # The sublaminate selection picks the thinner stack. With interface=1
@@ -177,20 +180,28 @@ def test_buckling_load_matches_closed_form_ssss_square():
 
     # Hand-evaluate the closed form at m=n=1.
     pi2 = math.pi * math.pi
-    N_cr_11 = (pi2 / a**2) * (
-        D11 * 1**4
-        + 2.0 * (D12 + 2.0 * D66) * (1 * aspect) ** 2 * 1**2
-        + D22 * (aspect * 1) ** 4
-    ) / 1**2
+    N_cr_11 = (
+        (pi2 / a**2)
+        * (
+            D11 * 1**4
+            + 2.0 * (D12 + 2.0 * D66) * (1 * aspect) ** 2 * 1**2
+            + D22 * (aspect * 1) ** 4
+        )
+        / 1**2
+    )
 
     # Sanity: m=n=1 really is the minimizer here (a == b, D11 == D22 by ±45
     # symmetry). Spot-check (2,1) and (1,2) to be safe.
     def _N_mn(mm, nn):
-        return (pi2 / a**2) * (
-            D11 * mm**4
-            + 2.0 * (D12 + 2.0 * D66) * (mm * aspect) ** 2 * nn**2
-            + D22 * (aspect * nn) ** 4
-        ) / mm**2
+        return (
+            (pi2 / a**2)
+            * (
+                D11 * mm**4
+                + 2.0 * (D12 + 2.0 * D66) * (mm * aspect) ** 2 * nn**2
+                + D22 * (aspect * nn) ** 4
+            )
+            / mm**2
+        )
 
     assert _N_mn(2, 1) > N_cr_11
     assert _N_mn(1, 2) > N_cr_11
@@ -230,15 +241,11 @@ def test_buckling_load_uses_full_plate_dimensions_not_semi_axes():
     # Closed form with the CORRECT full dimensions (a = b = 2*semi).
     a_full = 2.0 * semi
     pi2 = math.pi * math.pi
-    N_correct = (pi2 / a_full**2) * (
-        D11 + 2.0 * (D12 + 2.0 * D66) + D22
-    )
+    N_correct = (pi2 / a_full**2) * (D11 + 2.0 * (D12 + 2.0 * D66) + D22)
 
     # Closed form with the BUGGY semi-axis-as-side-length (a = semi).
     a_bug = semi
-    N_buggy = (pi2 / a_bug**2) * (
-        D11 + 2.0 * (D12 + 2.0 * D66) + D22
-    )
+    N_buggy = (pi2 / a_bug**2) * (D11 + 2.0 * (D12 + 2.0 * D66) + D22)
 
     # The bug would inflate by exactly 4x.
     assert N_buggy == pytest.approx(4.0 * N_correct, rel=1e-12)

--- a/tests/analysis/test_semi_analytical.py
+++ b/tests/analysis/test_semi_analytical.py
@@ -1,4 +1,9 @@
+import math
+
+import pytest
+
 from bvidfe.analysis.semi_analytical import (
+    _sublaminate_D_matrix,
     find_critical_interface,
     semi_analytical_cai,
     semi_analytical_tai,
@@ -122,3 +127,126 @@ def test_semi_analytical_tai_monotonic_in_dpa():
     t1 = semi_analytical_tai(lam, ds_small, 800.0)
     t2 = semi_analytical_tai(lam, ds_large, 800.0)
     assert t1 > t2
+
+
+def test_buckling_load_matches_closed_form_ssss_square():
+    """Regression test for Issue #29.
+
+    The closed-form SSSS Navier eigenvalue for an orthotropic rectangle is
+
+        N_cr(m,n) = (pi^2 / a^2)
+                    * [D11*m^4 + 2*(D12 + 2*D66)*(m*a/b)^2 * n^2
+                       + D22 * (a*n/b)^4] / m^2
+
+    where (a, b) are the FULL plate dimensions (the sine basis
+    sin(m*pi*x/a) * sin(n*pi*y/b) vanishes at x=0, x=a, y=0, y=b).
+    For an ellipse with semi-axes (major_mm, minor_mm), the enclosing
+    rectangle is (2*major_mm) x (2*minor_mm), so a = 2*major_mm.
+
+    Prior to the fix, the implementation passed a = major_mm directly,
+    inflating N_cr by ~4x (N_cr ∝ 1/a^2). This test pins the corrected
+    convention against a hand-computed value for a square sublaminate
+    with a balanced [45, -45]s layup (D11 = D22 and m=n=1 governs).
+    """
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    # Balanced ±45 sublaminate -> D11 == D22 by symmetry; D16 == D26 != 0
+    # but the closed form uses only D11, D22, D12, D66.
+    layup = [45.0, -45.0, -45.0, 45.0]
+    ply_t = 0.152
+    lam = Laminate(m, layup, ply_t)
+
+    # Square ellipse so the enclosing rectangle is square (a == b),
+    # which makes m=n=1 the analytic minimizer for any D with D11 == D22.
+    semi = 25.0  # mm
+    ell = DelaminationEllipse(
+        interface_index=1, centroid_mm=(0.0, 0.0),
+        major_mm=semi, minor_mm=semi, orientation_deg=0.0,
+    )
+
+    # The sublaminate selection picks the thinner stack. With interface=1
+    # and 4 plies total: upper = plies 0..1 (2 plies), lower = plies 2..3
+    # (2 plies); ties go to upper. So sub_layup = [45, -45].
+    sub_layup = [45.0, -45.0]
+    D = _sublaminate_D_matrix(m, sub_layup, ply_t)
+    D11, D22, D12, D66 = D[0, 0], D[1, 1], D[0, 1], D[2, 2]
+
+    # Full rectangle side lengths (a, b) per the corrected convention.
+    a = 2.0 * semi
+    b = 2.0 * semi
+    aspect = a / b  # == 1
+
+    # Hand-evaluate the closed form at m=n=1.
+    pi2 = math.pi * math.pi
+    N_cr_11 = (pi2 / a**2) * (
+        D11 * 1**4
+        + 2.0 * (D12 + 2.0 * D66) * (1 * aspect) ** 2 * 1**2
+        + D22 * (aspect * 1) ** 4
+    ) / 1**2
+
+    # Sanity: m=n=1 really is the minimizer here (a == b, D11 == D22 by ±45
+    # symmetry). Spot-check (2,1) and (1,2) to be safe.
+    def _N_mn(mm, nn):
+        return (pi2 / a**2) * (
+            D11 * mm**4
+            + 2.0 * (D12 + 2.0 * D66) * (mm * aspect) ** 2 * nn**2
+            + D22 * (aspect * nn) ** 4
+        ) / mm**2
+
+    assert _N_mn(2, 1) > N_cr_11
+    assert _N_mn(1, 2) > N_cr_11
+    assert _N_mn(2, 2) > N_cr_11
+
+    N_actual = sublaminate_buckling_load(lam, ell, boundary="simply_supported")
+    assert N_actual == pytest.approx(N_cr_11, rel=1e-10)
+
+    # And confirm the boundary factor is applied.
+    N_clamped = sublaminate_buckling_load(lam, ell, boundary="clamped")
+    assert N_clamped == pytest.approx(N_cr_11 * 1.9, rel=1e-10)
+
+
+def test_buckling_load_uses_full_plate_dimensions_not_semi_axes():
+    """Regression test for Issue #29 — verify the 4x-overprediction bug
+    does not regress.
+
+    If the implementation reverted to using ellipse semi-axes directly as
+    (a, b), N_cr would be inflated by exactly (2*r / r)^2 = 4 (since the
+    eigenvalue is homogeneous of degree -2 in length when a/b is held fixed).
+    Build two cases differing only in scale and check the corrected
+    scaling, then independently check the magnitude against the
+    "semi-axis-as-a" miscalculation.
+    """
+    mat = MATERIAL_LIBRARY["IM7/8552"]
+    ply_t = 0.152
+    lam = Laminate(mat, [0.0, 90.0, 90.0, 0.0], ply_t)
+
+    semi = 20.0  # mm
+    ell = DelaminationEllipse(1, (0.0, 0.0), semi, semi, 0.0)
+
+    # Sub layup is the thinner of [0, 90] vs [90, 0]; tie -> upper -> [0, 90].
+    sub_layup = [0.0, 90.0]
+    D = _sublaminate_D_matrix(mat, sub_layup, ply_t)
+    D11, D22, D12, D66 = D[0, 0], D[1, 1], D[0, 1], D[2, 2]
+
+    # Closed form with the CORRECT full dimensions (a = b = 2*semi).
+    a_full = 2.0 * semi
+    pi2 = math.pi * math.pi
+    N_correct = (pi2 / a_full**2) * (
+        D11 + 2.0 * (D12 + 2.0 * D66) + D22
+    )
+
+    # Closed form with the BUGGY semi-axis-as-side-length (a = semi).
+    a_bug = semi
+    N_buggy = (pi2 / a_bug**2) * (
+        D11 + 2.0 * (D12 + 2.0 * D66) + D22
+    )
+
+    # The bug would inflate by exactly 4x.
+    assert N_buggy == pytest.approx(4.0 * N_correct, rel=1e-12)
+
+    # Verify D11 == D22 for this symmetric cross-ply (so m=n=1 governs at a=b)
+    assert D11 == pytest.approx(D22, rel=1e-12)
+
+    N_actual = sublaminate_buckling_load(lam, ell, boundary="simply_supported")
+    assert N_actual == pytest.approx(N_correct, rel=1e-10)
+    # And explicitly rule out the buggy value.
+    assert N_actual < 0.5 * N_buggy

--- a/tests/test_per_ply_thickness.py
+++ b/tests/test_per_ply_thickness.py
@@ -151,6 +151,120 @@ def test_per_ply_thickness_preserves_finite_knockdown():
     assert math.isfinite(r.residual_strength_MPa)
 
 
+def test_sublaminate_selection_uses_thickness_not_ply_count():
+    """Regression for issue #18.
+
+    The sublaminate-buckling selection must pick the geometrically thinner
+    stack (by sum of per-ply thicknesses), not the side with fewer plies.
+    Configuration: ``layup=[0, 90, 0, 90, 0, 90]``, ``ply_thickness_mm=
+    [0.5, 0.5, 0.1, 0.1, 0.1, 0.1]``, ``interface_index=1``.
+
+    At interface 1 the upper sublaminate is plies 0..1 (2 plies, 1.0 mm
+    total) and the lower is plies 2..5 (4 plies, 0.4 mm total). Ply count
+    says "upper is thinner"; through-thickness says "lower is thinner".
+    The geometrically thinner stack is what actually buckles first, so the
+    function must return the buckling load of the *lower* sublaminate.
+    """
+    from bvidfe.analysis.semi_analytical import (
+        _sublaminate_D_matrix,
+        semi_analytical_cai,
+        sublaminate_buckling_load,
+    )
+    from bvidfe.core.laminate import Laminate
+    from bvidfe.core.material import MATERIAL_LIBRARY
+
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    layup = [0, 90, 0, 90, 0, 90]
+    thicknesses = [0.5, 0.5, 0.1, 0.1, 0.1, 0.1]
+    lam = Laminate(material=m, layup_deg=layup, ply_thickness_mm=thicknesses)
+
+    upper_layup, upper_t = layup[:2], thicknesses[:2]
+    lower_layup, lower_t = layup[2:], thicknesses[2:]
+    assert sum(upper_t) > sum(lower_t)  # upper geometrically thicker
+    assert len(upper_layup) < len(lower_layup)  # but has fewer plies
+
+    # D matrices of each candidate sublaminate — the geometrically thinner
+    # stack (lower) has much smaller D11/D22 because D scales as t^3.
+    D_upper = _sublaminate_D_matrix(m, upper_layup, upper_t)
+    D_lower = _sublaminate_D_matrix(m, lower_layup, lower_t)
+    assert D_lower[0, 0] < D_upper[0, 0]
+    assert D_lower[1, 1] < D_upper[1, 1]
+
+    # Buckling load with the function under test. Use an ellipse large
+    # enough that the (a/b)^4 aspect-ratio clip never fires.
+    ell = DelaminationEllipse(1, (0.0, 0.0), major_mm=20.0, minor_mm=15.0, orientation_deg=0.0)
+    N = sublaminate_buckling_load(lam, ell)
+
+    # Reference loads from each candidate sublaminate's D matrix, evaluated
+    # with the same closed-form (m, n) in [1..5] x [1..5] minimisation that
+    # ``sublaminate_buckling_load`` uses internally.
+    def _ref_Ncr(D, a, b):
+        D11, D22, D12, D66 = D[0, 0], D[1, 1], D[0, 1], D[2, 2]
+        pi2 = math.pi * math.pi
+        aspect = a / b
+        best = math.inf
+        for mm in range(1, 6):
+            for nn in range(1, 6):
+                num = (
+                    D11 * mm**4
+                    + 2.0 * (D12 + 2.0 * D66) * (mm * aspect) ** 2 * nn**2
+                    + D22 * (aspect * nn) ** 4
+                )
+                cand = (pi2 / a**2) * num / mm**2
+                if cand < best:
+                    best = cand
+        return best
+
+    N_upper_ref = _ref_Ncr(D_upper, ell.major_mm, ell.minor_mm)
+    N_lower_ref = _ref_Ncr(D_lower, ell.major_mm, ell.minor_mm)
+    assert N_lower_ref < N_upper_ref  # thinner stack buckles at lower load
+
+    # The function must report the *lower* (geometrically thinner)
+    # sublaminate's buckling load — not the upper (fewer-plies) stack.
+    assert N == pytest.approx(N_lower_ref, rel=1e-12)
+    assert not math.isclose(N, N_upper_ref, rel_tol=1e-6)
+
+    # End-to-end: semi_analytical_cai must use the same geometrically
+    # thinner sublaminate for its h_sub normalisation. Drive the buckling
+    # tier with a large delamination at interface 1 so it controls the min.
+    ds = DamageState(
+        [DelaminationEllipse(1, (0.0, 0.0), 60.0, 40.0, 0.0)],
+        dent_depth_mm=0.5,
+    )
+    sigma_cai, crit_idx, N_cr = semi_analytical_cai(
+        lam, ds, sigma_pristine_MPa=500.0, A_panel_mm2=15000.0
+    )
+    assert crit_idx == 1
+    # h_sub must equal the lower (thinner) stack's total thickness (0.4 mm),
+    # so sigma_buckling = N_cr / 0.4. If the buggy logic picked the upper
+    # stack we'd divide by 1.0 mm instead and get a stress 2.5x smaller.
+    sigma_buckling_expected = N_cr / sum(lower_t)
+    assert sigma_cai == pytest.approx(min(sigma_buckling_expected, 500.0), rel=1e-9)
+
+
+def test_sublaminate_selection_matches_uniform_for_uniform_laminate():
+    """For uniform per-ply thicknesses the new thickness-based selection
+    must agree with the old ply-count-based selection: every test in
+    ``tests/analysis/test_semi_analytical.py`` uses a uniform layup, so
+    pin the equivalence explicitly here too."""
+    from bvidfe.analysis.semi_analytical import sublaminate_buckling_load
+    from bvidfe.core.laminate import Laminate
+    from bvidfe.core.material import MATERIAL_LIBRARY
+
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    # Asymmetric ply count around the interface so ply count and thickness
+    # would disagree if thicknesses were ever non-uniform; here they aren't,
+    # so both criteria must select the same (smaller-ply-count) side.
+    layup = [0, 45, -45, 90, 90, -45, 45, 0, 0, 45]  # 10 plies
+    lam_scalar = Laminate(m, layup, 0.152)
+    lam_list = Laminate(m, layup, [0.152] * len(layup))
+    ell = DelaminationEllipse(2, (0, 0), 20, 12, 0)
+    N_scalar = sublaminate_buckling_load(lam_scalar, ell)
+    N_list = sublaminate_buckling_load(lam_list, ell)
+    assert N_scalar == pytest.approx(N_list, rel=1e-12)
+    assert N_scalar > 0
+
+
 def test_fe3d_runs_with_per_ply_thickness():
     """fe3d builds a structured hex mesh whose z-grid follows per-ply
     boundaries; verify it doesn't crash and reports a finite residual on a

--- a/tests/test_per_ply_thickness.py
+++ b/tests/test_per_ply_thickness.py
@@ -215,8 +215,9 @@ def test_sublaminate_selection_uses_thickness_not_ply_count():
                     best = cand
         return best
 
-    N_upper_ref = _ref_Ncr(D_upper, ell.major_mm, ell.minor_mm)
-    N_lower_ref = _ref_Ncr(D_lower, ell.major_mm, ell.minor_mm)
+    # (a, b) are FULL plate side lengths (= 2 * ellipse semi-axes); see #29.
+    N_upper_ref = _ref_Ncr(D_upper, 2.0 * ell.major_mm, 2.0 * ell.minor_mm)
+    N_lower_ref = _ref_Ncr(D_lower, 2.0 * ell.major_mm, 2.0 * ell.minor_mm)
     assert N_lower_ref < N_upper_ref  # thinner stack buckles at lower load
 
     # The function must report the *lower* (geometrically thinner)

--- a/tests/validation/test_olsson_threshold_reference.py
+++ b/tests/validation/test_olsson_threshold_reference.py
@@ -11,8 +11,14 @@ for a self-contained regression test.
 The shape relationships, in contrast, follow directly from the closed
 form and must hold for every BVID-FE material:
   * Pc scales as sqrt(G_IIc) when D_eff is held fixed.
-  * Pc scales as h^{3/2} when E_ij are held fixed (D_eff ~ E*h^3, sqrt
-    gives h^{3/2}; this is exact CLT).
+  * Pc scales as h^{3/2} under a SELF-SIMILAR thickness scaling, i.e.
+    holding the layup fixed and scaling ply thickness (so every ply's
+    relative z-position is preserved). Under CLT D_ij integrates
+    Q_bar_k * (z_{k+1}^3 - z_k^3)/3, so D_eff = sqrt(D11*D22) only
+    scales as h^3 when the ply positions scale uniformly with h.
+    Concatenating a layup (e.g. ``[0,45,-45,90]*2``) does NOT preserve
+    relative positions -- it rearranges plies in z and gives an effective
+    exponent below 1.5 (see issue #44).
   * Pc is a property of the laminate + impactor and is INDEPENDENT of
     panel size, so the same Laminate+ImpactorGeometry should yield the
     same Pc on a 100x100 mm and 200x150 mm panel.
@@ -84,23 +90,27 @@ def test_threshold_load_invariant_to_panel_size():
     assert Pc_small == pytest.approx(Pc_large, rel=1e-12)
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Empirical ratio is ~2.65 vs theoretical 2^{3/2}=2.83 (~6.5% off). "
-        "Either Pc has a sub-h^{3/2} contribution from the ply-by-ply "
-        "Q_bar→D_eff path, or the test's 1% tolerance is too tight for the "
-        "discrete-stack case. Needs maintainer review of model vs scaling law."
-    ),
-    strict=True,
-)
 def test_threshold_load_scales_with_thickness_to_the_three_halves():
-    """Doubling the layup count (same material, same angles) raises h
-    by the layup-count factor; D_eff scales as h^3, Pc as h^{3/2}."""
+    """Pc scales as h^{3/2} under a self-similar thickness change.
+
+    The Olsson closed form gives Pc = pi * sqrt(8 * G_IIc * D_eff / 9),
+    where D_eff = sqrt(D11 * D22). The CLT D-matrix is
+    ``D_ij = (1/3) * sum_k Q_bar_ij,k * (z_{k+1}^3 - z_k^3)``, so D_eff
+    scales as h^3 -- and therefore Pc as h^{3/2} -- ONLY when each ply's
+    relative through-thickness position is preserved as h changes. That
+    means a self-similar scaling: keep the layup fixed and scale the ply
+    thickness. Doubling the layup count (e.g. ``[0,45,-45,90] * 2``)
+    does NOT preserve relative positions -- it rearranges where the 0/45
+    /-45/90 plies sit in z, which changes their D_ij weighting and gives
+    a numerical exponent <1.5 (originally tracked in issue #44).
+    """
     base_layup = [0, 45, -45, 90]
-    lam_thin = _laminate("IM7/8552", base_layup)  # 4 plies
-    lam_thick = _laminate("IM7/8552", base_layup * 2)  # 8 plies
+    t_thin = 0.152
+    t_thick = 2.0 * t_thin
+    lam_thin = _laminate("IM7/8552", base_layup, t_ply=t_thin)
+    lam_thick = _laminate("IM7/8552", base_layup, t_ply=t_thick)
     pan, imp = _panel(), _impactor()
     Pc_thin = threshold_load(lam_thin, pan, imp)
     Pc_thick = threshold_load(lam_thick, pan, imp)
     # h_thick / h_thin = 2 -> Pc_thick / Pc_thin = 2^{3/2} = 2.828...
-    assert Pc_thick / Pc_thin == pytest.approx(2**1.5, rel=1e-2)
+    assert Pc_thick / Pc_thin == pytest.approx(2**1.5, rel=1e-9)


### PR DESCRIPTION
## Summary
This PR fixes critical bugs in the semi-analytical buckling analysis and improves memory efficiency in the FE solver. The main issues addressed are:

1. **Issue #29**: The sublaminate buckling load was overpredicting by ~4x due to using ellipse semi-axes instead of full rectangle dimensions in the closed-form eigenvalue formula.
2. **Issue #18**: Sublaminate selection was based on ply count instead of geometric thickness, causing incorrect selection for non-uniform laminates.
3. **Issue #33**: Memory efficiency in sparse matrix assembly was poor due to list-of-chunks concatenation patterns.

## Key Changes

### Buckling Load Calculation (Issue #29)
- **Root cause**: The Navier closed-form eigenvalue formula requires full rectangle side lengths `(a, b)`, not semi-axes. The sine basis `sin(m*pi*x/a) * sin(n*pi*y/b)` vanishes at the boundaries, so `a` and `b` must span the full domain for SSSS boundary conditions to be satisfied.
- **Fix**: Changed `a = ellipse.major_mm` to `a = 2.0 * ellipse.major_mm` (and similarly for `b`). This corrects the ~4x overprediction since `N_cr ∝ 1/a²`.
- **Tests added**: 
  - `test_buckling_load_matches_closed_form_ssss_square()`: Validates against hand-computed closed-form values
  - `test_buckling_load_uses_full_plate_dimensions_not_semi_axes()`: Explicitly checks the 4x bug doesn't regress
- **Documentation**: Updated docstrings to clarify that `(a, b)` are full rectangle dimensions, matching the Timoshenko & Gere and Reddy references.

### Sublaminate Selection (Issue #18)
- **Root cause**: Selection logic used `len(upper_layup) <= len(lower_layup)` (ply count), but the geometrically thinner stack (by through-thickness sum) is what buckles first.
- **Fix**: Changed selection to compare `sum(upper_thicknesses)` vs `sum(lower_thicknesses)` in both `sublaminate_buckling_load()` and `semi_analytical_cai()`.
- **Tests added**:
  - `test_sublaminate_selection_uses_thickness_not_ply_count()`: Demonstrates the bug with a 6-ply laminate where ply count and thickness disagree
  - `test_sublaminate_selection_matches_uniform_for_uniform_laminate()`: Ensures backward compatibility for uniform laminates
- **Impact**: For non-uniform laminates, now correctly selects the thinner stack for buckling analysis.

### Memory Efficiency (Issue #33)
- **Root cause**: Both `assemble_global_stiffness()` and the geometric stiffness assembly in `fe3d_cai_buckling()` used list-of-chunks COO assembly, concatenating arrays per element. Near the FE3D_MAX_DOF cap (~166k elements), this doubled peak memory usage.
- **Fix**: 
  - Extracted common COO assembly logic into a new `assemble_coo()` function that pre-allocates contiguous buffers (`np.empty(n_elem * 576)`) instead of appending.
  - Refactored `assemble_global_stiffness()` as a thin wrapper around `assemble_coo()` for backward compatibility.
  - Updated `fe3d_cai_buckling()` to use `assemble_coo()` for geometric stiffness, eliminating the list-of-chunks pattern.
  - Added explicit `del K` after penalty application to free memory before ARPACK eigensolver allocation.
- **Performance**: Halves transient memory held alive before `coo_matrix.tocsc()` conversion on large problems.

### Test Suite Updates
- Fixed `test_threshold_load_scales_with_thickness_to_the_three_halves()` (was xfail): Now uses self-similar thickness scaling (scale ply thickness

https://claude.ai/code/session_014gmVBugs9a1wwiUnx6MAvy