### PR TITLE
Perf: cache Navier sin² basis in Olsson onset path (#85)

### DIFF
--- a/src/bvidfe/impact/olsson.py
+++ b/src/bvidfe/impact/olsson.py
@@ -33,6 +33,9 @@ from __future__ import annotations
 
 import math
 import warnings
+from functools import lru_cache
+
+import numpy as np
 
 from bvidfe.core.geometry import ImpactorGeometry, PanelGeometry
 from bvidfe.core.laminate import Laminate
@@ -59,6 +62,35 @@ _BOUNDARY_BENDING_FACTOR: dict[str, float] = {
 _CONICAL_HALF_ANGLE_DEG: float = 30.0
 
 
+@lru_cache(maxsize=64)
+def _navier_basis_ssss(
+    Lx_mm: float,
+    Ly_mm: float,
+    x0: float,
+    y0: float,
+    n_modes: int = NAVIER_N,
+) -> np.ndarray:
+    """Cached geometric Navier basis for a simply-supported rectangular plate.
+
+    Returns a read-only ``(n_modes, n_modes)`` array whose ``(m-1, n-1)`` entry
+    is ``sin^2(m*pi*x0/Lx_mm) * sin^2(n*pi*y0/Ly_mm)``. This factor depends
+    only on the panel geometry and the impact location, not on the laminate,
+    so it can be reused across energy-sweep iterations that vary only the
+    laminate stack or material properties.
+
+    The result is marked read-only via ``arr.setflags(write=False)`` so cache
+    hits cannot be polluted by callers mutating the array. Callers that need
+    to mutate should copy first.
+    """
+    m_idx = np.arange(1, n_modes + 1, dtype=float)
+    n_idx = np.arange(1, n_modes + 1, dtype=float)
+    sin_mx = np.sin(m_idx * math.pi * x0 / Lx_mm)
+    sin_ny = np.sin(n_idx * math.pi * y0 / Ly_mm)
+    basis = (sin_mx[:, None] ** 2) * (sin_ny[None, :] ** 2)
+    basis.setflags(write=False)
+    return basis
+
+
 def _k_bending_ssss(
     lam: Laminate,
     pan: PanelGeometry,
@@ -77,18 +109,13 @@ def _k_bending_ssss(
     _, _, D = lam.abd_matrices()
     D11, D22, D12, D66 = D[0, 0], D[1, 1], D[0, 1], D[2, 2]
     a, b = pan.Lx_mm, pan.Ly_mm
-    w_over_P = 0.0
-    for m in range(1, n_modes + 1):
-        for n in range(1, n_modes + 1):
-            sin_mx = math.sin(m * math.pi * x0 / a)
-            sin_ny = math.sin(n * math.pi * y0 / b)
-            Dmn = (
-                D11 * (m * math.pi / a) ** 4
-                + 2 * (D12 + 2 * D66) * (m * math.pi / a) ** 2 * (n * math.pi / b) ** 2
-                + D22 * (n * math.pi / b) ** 4
-            )
-            w_over_P += (sin_mx * sin_ny) ** 2 / Dmn
-    w_over_P *= 4.0 / (a * b)
+    basis = _navier_basis_ssss(a, b, x0, y0, n_modes)
+    m_idx = np.arange(1, n_modes + 1, dtype=float)
+    n_idx = np.arange(1, n_modes + 1, dtype=float)
+    km = (m_idx * math.pi / a)[:, None]
+    kn = (n_idx * math.pi / b)[None, :]
+    Dmn = D11 * km**4 + 2.0 * (D12 + 2.0 * D66) * (km**2) * (kn**2) + D22 * kn**4
+    w_over_P = float(np.sum(basis / Dmn)) * 4.0 / (a * b)
     return 1.0 / w_over_P
 
 

--- a/tests/impact/test_navier_basis_cache.py
+++ b/tests/impact/test_navier_basis_cache.py
@@ -1,0 +1,60 @@
+"""Regression tests for the ``_navier_basis_ssss`` lru_cache (issue #85).
+
+In Streamlit energy sweeps the panel geometry and impact location are constant
+across iterations; we cache the geometric Navier basis so the ~121-term
+``sin^2`` evaluation is not repeated for every laminate / energy point.
+"""
+
+import numpy as np
+import pytest
+
+from bvidfe.core.geometry import ImpactorGeometry, PanelGeometry
+from bvidfe.core.laminate import Laminate
+from bvidfe.core.material import MATERIAL_LIBRARY
+from bvidfe.impact.olsson import NAVIER_N, _navier_basis_ssss, onset_energy
+
+
+@pytest.fixture(autouse=True)
+def _clear_navier_basis_cache():
+    """Isolate each test from cache state set by prior tests."""
+    _navier_basis_ssss.cache_clear()
+    yield
+    _navier_basis_ssss.cache_clear()
+
+
+def test_navier_basis_cache_hits_on_repeat_call():
+    a, b, x0, y0 = 150.0, 100.0, 75.0, 50.0
+    arr1 = _navier_basis_ssss(a, b, x0, y0, NAVIER_N)
+    arr2 = _navier_basis_ssss(a, b, x0, y0, NAVIER_N)
+    info = _navier_basis_ssss.cache_info()
+    assert info.hits >= 1
+    # Same object returned on cache hit.
+    assert arr1 is arr2
+
+
+def test_navier_basis_is_readonly():
+    arr = _navier_basis_ssss(150.0, 100.0, 75.0, 50.0, NAVIER_N)
+    assert arr.flags.writeable is False
+    with pytest.raises(ValueError):
+        arr[0, 0] = 999.0
+
+
+def test_navier_basis_shape_and_values():
+    a, b, x0, y0 = 150.0, 100.0, 75.0, 50.0
+    arr = _navier_basis_ssss(a, b, x0, y0, NAVIER_N)
+    assert arr.shape == (NAVIER_N, NAVIER_N)
+    # Spot-check (m, n) = (1, 1): sin^2(pi/2) * sin^2(pi/2) = 1.
+    assert np.isclose(arr[0, 0], 1.0)
+
+
+def test_onset_energy_energy_sweep_hits_cache():
+    """An energy-sweep-style loop should produce cache hits on the basis."""
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    lam = Laminate(m, [0, 45, -45, 90] * 4, 0.152)
+    pan = PanelGeometry(150, 100)
+    imp = ImpactorGeometry()
+    # Call onset_energy several times with identical geometry+location.
+    for _ in range(5):
+        onset_energy(lam, pan, imp)
+    info = _navier_basis_ssss.cache_info()
+    assert info.hits >= 4


### PR DESCRIPTION
Closes #85.

## Summary
- Factored out `_navier_basis_ssss(Lx_mm, Ly_mm, x0, y0, n_modes)` from `_k_bending_ssss`, wrapped it with `@functools.lru_cache(maxsize=64)`, and returned a read-only `(n_modes, n_modes)` ndarray of `sin²(m·π·x0/a) · sin²(n·π·y0/b)`.
- `_k_bending_ssss` now consumes the cached basis and vectorises the `D_mn` denominator via numpy.
- Added 4 regression tests in `tests/impact/test_navier_basis_cache.py`: cache-hit on repeat, read-only enforcement, shape/value spot-check, and an `onset_energy` sweep asserting `hits >= 4`. Autouse fixture clears the cache between tests.

## Test plan
- [x] `pytest -x` → 315 passed, 1 xfailed (+4 new)
- [x] `black src tests` and `ruff check src tests` clean
- [ ] CI green on this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTG1A1VE1zUzrF8TQM8Dxe)_