### PR TITLE
Perf: memoize Hex8Element Voigt rotation matrix by ply angle (#86)

### DIFF
--- a/src/bvidfe/elements/hex8.py
+++ b/src/bvidfe/elements/hex8.py
@@ -10,6 +10,7 @@ Natural coordinates xi, eta, zeta in [-1, 1].
 
 from __future__ import annotations
 
+import functools
 from dataclasses import dataclass
 
 import numpy as np
@@ -90,8 +91,17 @@ _NODE_COORDS = np.array(
 )
 
 
+@functools.lru_cache(maxsize=64)
 def _T_sigma_z(theta_rad: float) -> np.ndarray:
-    """Voigt stress transformation matrix for rotation about the z-axis."""
+    """Voigt stress transformation matrix for rotation about the z-axis.
+
+    Cached on ``theta_rad`` because a typical mesh has 1e4-1e5 elements but
+    only a handful of distinct ply angles (e.g. a [0/45/-45/90] layup has
+    four), so the same 6x6 matrix is otherwise recomputed thousands of times.
+    The returned array is marked read-only so that downstream callers cannot
+    silently corrupt the cached entry via in-place mutation; ``_compute_
+    global_stiffness`` only reads ``T`` via ``T @ C @ T.T``, which is safe.
+    """
     c, s = np.cos(theta_rad), np.sin(theta_rad)
     T = np.array(
         [
@@ -104,6 +114,7 @@ def _T_sigma_z(theta_rad: float) -> np.ndarray:
         ],
         dtype=float,
     )
+    T.setflags(write=False)
     return T
 
 

--- a/tests/elements/test_hex8_voigt_cache.py
+++ b/tests/elements/test_hex8_voigt_cache.py
@@ -1,0 +1,69 @@
+"""Regression tests for ``_T_sigma_z`` lru_cache memoization (issue #86).
+
+The 6x6 Voigt stress-rotation matrix is rebuilt once per element by
+``Hex8Element._compute_global_stiffness``. On a typical mesh with 1e4-1e5
+elements but only a handful of distinct ply angles, identical-angle
+recomputation dominates element-construction cost. These tests pin the
+cache behaviour so future refactors do not silently disable it.
+"""
+
+import numpy as np
+
+from bvidfe.core.material import MATERIAL_LIBRARY
+from bvidfe.elements.hex8 import Hex8Element, _T_sigma_z
+
+
+def _unit_cube_nodes() -> np.ndarray:
+    return np.array(
+        [
+            [0, 0, 0],
+            [1, 0, 0],
+            [1, 1, 0],
+            [0, 1, 0],
+            [0, 0, 1],
+            [1, 0, 1],
+            [1, 1, 1],
+            [0, 1, 1],
+        ],
+        dtype=float,
+    )
+
+
+def test_t_sigma_z_lru_cache_hits_on_repeated_angle():
+    """Second call with the same theta must hit the cache, not recompute."""
+    _T_sigma_z.cache_clear()
+    theta = np.radians(45.0)
+    first = _T_sigma_z(theta)
+    info_after_first = _T_sigma_z.cache_info()
+    second = _T_sigma_z(theta)
+    info_after_second = _T_sigma_z.cache_info()
+
+    # First call: a miss; second call: a hit.
+    assert info_after_first.misses == 1
+    assert info_after_first.hits == 0
+    assert info_after_second.hits == 1
+    assert info_after_second.misses == 1
+    # Cache returns the *same* underlying array, not a fresh copy.
+    assert second is first
+
+
+def test_t_sigma_z_returns_read_only_array():
+    """The cached matrix must be read-only so callers cannot corrupt it."""
+    _T_sigma_z.cache_clear()
+    T = _T_sigma_z(np.radians(30.0))
+    assert T.flags.writeable is False
+
+
+def test_compute_global_stiffness_reuses_cache_across_elements():
+    """Many Hex8Elements at the same ply angle must share one cached T."""
+    _T_sigma_z.cache_clear()
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    # Build ten elements at +45 deg and ten at -45 deg — only two cache misses
+    # should occur regardless of element count.
+    for _ in range(10):
+        Hex8Element(_unit_cube_nodes(), m, ply_angle_deg=45.0)
+    for _ in range(10):
+        Hex8Element(_unit_cube_nodes(), m, ply_angle_deg=-45.0)
+    info = _T_sigma_z.cache_info()
+    assert info.misses == 2
+    assert info.hits == 18


### PR DESCRIPTION
Closes #86.

## Summary
- Wrapped module-level `_T_sigma_z` with `@functools.lru_cache(maxsize=64)` keyed on `theta_rad`; the returned 6×6 Voigt rotation matrix is marked read-only via `setflags(write=False)`.
- Audit: `_T_sigma_z`'s only caller (`Hex8Element._compute_global_stiffness`) uses the matrix as `T @ C @ T.T` — read-only safe. `_build_elements` in `fe_tier.py` reuses cached results across all elements sharing a ply angle.
- Added 3 regression tests in `tests/elements/test_hex8_voigt_cache.py`: cache-hit verification, read-only flag, and reuse across many `Hex8Element` instances.

## Test plan
- [x] `pytest -x` → 314 passed, 1 xfailed (+3 new)
- [x] `black src tests` and `ruff check src tests` clean
- [ ] CI green on this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTG1A1VE1zUzrF8TQM8Dxe)_