### PR TITLE
CI/tests: enforce 90% coverage floor and add public-API export smoke tests (#88)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,19 @@ jobs:
       - run: pip install -e ".[dev]"
       - run: ruff check src tests
       - run: black --check src tests
-      - run: pytest -v
+      # Coverage gate. Measured baseline on main was ~93% (2026-05); the
+      # floor is set to 90% (current value rounded DOWN to the nearest 5%)
+      # so routine refactors don't break CI while still catching meaningful
+      # regressions. Raise this floor in a follow-up PR once coverage is
+      # consistently higher.
+      - run: pytest -v --cov=bvidfe --cov-report=xml --cov-report=term --cov-fail-under=90
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: coverage.xml
+          if-no-files-found: ignore
 
   validation:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=7,<9", "ruff>=0.5,<1", "black>=24,<26", "pre-commit>=3,<5"]
+dev = ["pytest>=7,<9", "pytest-cov>=4,<7", "ruff>=0.5,<1", "black>=24,<26", "pre-commit>=3,<5"]
 
 [project.urls]
 Homepage = "https://github.com/ranipdx-glitch/BVID-FE"

--- a/tests/test_public_api_exports.py
+++ b/tests/test_public_api_exports.py
@@ -1,0 +1,63 @@
+"""Smoke tests for the public API surface of ``bvidfe``.
+
+These tests guard against accidental drift in ``bvidfe/__init__.py`` —
+specifically the names re-exported via ``__all__``. The goal is to fail
+CI the moment a top-level export is removed or renamed, instead of
+waiting for a downstream user to complain.
+
+Two layers of checks:
+    1. Every name in ``bvidfe.__all__`` must resolve as an attribute on
+       the ``bvidfe`` module (parametrized).
+    2. A minimal end-to-end constructor smoke: build an ``AnalysisConfig``
+       and instantiate ``BvidAnalysis(cfg)`` without calling ``.run()``,
+       to confirm the public construction path is intact.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import bvidfe
+
+
+def test_all_attribute_exists():
+    """``bvidfe`` must declare an ``__all__`` for the public-export contract."""
+    assert hasattr(bvidfe, "__all__"), "bvidfe.__init__ must define __all__"
+    assert isinstance(bvidfe.__all__, list)
+    assert len(bvidfe.__all__) > 0, "bvidfe.__all__ must not be empty"
+
+
+@pytest.mark.parametrize("name", bvidfe.__all__)
+def test_public_export_resolves(name: str) -> None:
+    """Each name in ``bvidfe.__all__`` must be importable from the top level."""
+    assert hasattr(bvidfe, name), f"bvidfe.__all__ advertises {name!r} but it is missing"
+    obj = getattr(bvidfe, name)
+    assert obj is not None, f"bvidfe.{name} resolved to None"
+
+
+def test_bvid_analysis_constructor_smoke() -> None:
+    """End-to-end public-API smoke: build a config and construct the runner.
+
+    Does NOT call ``.run()`` — we only want to confirm that the public
+    constructors wired through ``bvidfe.__init__`` still accept the
+    documented inputs and produce the documented objects.
+    """
+    from bvidfe import (
+        AnalysisConfig,
+        BvidAnalysis,
+        ImpactEvent,
+        ImpactorGeometry,
+        PanelGeometry,
+    )
+
+    cfg = AnalysisConfig(
+        material="IM7/8552",
+        layup_deg=[0, 45, -45, 90, 90, -45, 45, 0],
+        ply_thickness_mm=0.152,
+        panel=PanelGeometry(150.0, 100.0),
+        loading="compression",
+        tier="empirical",
+        impact=ImpactEvent(20.0, ImpactorGeometry(), mass_kg=5.5),
+    )
+    analysis = BvidAnalysis(cfg)
+    assert analysis.config is cfg


### PR DESCRIPTION
Closes #88.

## Summary
- Added `pytest-cov>=4,<7` to `[project.optional-dependencies].dev`.
- Switched `.github/workflows/tests.yml` to `pytest -v --cov=bvidfe --cov-report=xml --cov-report=term --cov-fail-under=90` and uploaded `coverage.xml` per matrix cell via `actions/upload-artifact@v4`.
- Threshold chosen conservatively: current measured coverage is 92.74 %, floor set to 90 % (next-lower 5 %). Workflow comment invites a follow-up bump.
- Added `tests/test_public_api_exports.py` parametrising over `bvidfe.__all__` (13 names) plus a constructor smoke that builds `AnalysisConfig` and instantiates `BvidAnalysis(cfg)` without `.run()`.

## Test plan
- [x] `pytest -x` → 326 passed, 1 xfailed (+15 new)
- [x] `black --check` and `ruff check` clean
- [ ] CI green on this PR (covers the new coverage gate end-to-end)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTG1A1VE1zUzrF8TQM8Dxe)_