### PR TITLE
style: black-format tests/test_cli_reproducibility.py

### DIFF
--- a/tests/test_cli_reproducibility.py
+++ b/tests/test_cli_reproducibility.py
@@ -45,7 +45,6 @@ from typing import Any
 
 import pytest
 
-
 # Each entry: (id, CLI args, expected JSON snapshot fields).
 # Snapshots captured 2026-05-20 against bvidfe 0.2.0.dev0 with
 # numpy 2.x and scipy 1.14.x on linux x86_64.


### PR DESCRIPTION
## Summary
Removes one extraneous blank line in `tests/test_cli_reproducibility.py` that `black --check` flags. The file was added in PR #97 by an agent whose local `black` produced slightly different output; this aligns it with the version pinned in dev deps so the SessionStart hook and any future `black --check` step in CI stay clean.

Trivial 1-line removal, no functional change.

## Test plan
- [x] `black --check tests/test_cli_reproducibility.py` → clean
- [x] Existing CLI snapshot tests still pass (no logic changed)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTG1A1VE1zUzrF8TQM8Dxe)_