### PR TITLE
types: introduce shared Literal aliases for AnalysisConfig (#82, scoped)

### DIFF
--- a/src/bvidfe/_types.py
+++ b/src/bvidfe/_types.py
@@ -1,0 +1,51 @@
+"""Shared Literal type aliases and their runtime-validation sets.
+
+This module centralises the small set of string-enum-style options that flow
+through ``AnalysisConfig`` and the analysis pipeline so they can be referenced
+from a single place. Caller modules (e.g. ``bvid.py``, ``fe_tier.py``,
+``failure/evaluator.py``) will migrate to these aliases in follow-up PRs;
+this PR only wires them through :class:`bvidfe.analysis.config.AnalysisConfig`.
+
+The frozensets ``_TIER_NAMES``, ``_LOADING_MODES``, and ``_CRITERION_NAMES``
+mirror each ``Literal`` so callers have an O(1) runtime-validation set that
+stays in sync with the static type. Keep the two in lockstep when adding new
+values.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+# ---------------------------------------------------------------------------
+# Literal aliases
+# ---------------------------------------------------------------------------
+
+#: Identifier for the analysis tier selected on ``AnalysisConfig.tier``.
+TierName = Literal["empirical", "semi_analytical", "fe3d"]
+
+#: In-plane loading mode selected on ``AnalysisConfig.loading``.
+LoadingMode = Literal["compression", "tension"]
+
+#: Failure-criterion name. ``failure/evaluator.py`` currently defines its own
+#: ``CriterionName`` alias; this duplicate exists so future callers can import
+#: from a single place once the evaluator is migrated in a follow-up PR.
+CriterionName = Literal["tsai_wu", "larc05"]
+
+
+# ---------------------------------------------------------------------------
+# Runtime-validation sets (keep in lockstep with the Literals above)
+# ---------------------------------------------------------------------------
+
+_TIER_NAMES: frozenset[str] = frozenset({"empirical", "semi_analytical", "fe3d"})
+_LOADING_MODES: frozenset[str] = frozenset({"compression", "tension"})
+_CRITERION_NAMES: frozenset[str] = frozenset({"tsai_wu", "larc05"})
+
+
+__all__ = [
+    "TierName",
+    "LoadingMode",
+    "CriterionName",
+    "_TIER_NAMES",
+    "_LOADING_MODES",
+    "_CRITERION_NAMES",
+]

--- a/src/bvidfe/analysis/config.py
+++ b/src/bvidfe/analysis/config.py
@@ -3,12 +3,25 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Literal, Optional, Sequence, Union
+from typing import Iterable, List, Optional, Sequence, Union
 
+from bvidfe._types import _LOADING_MODES, _TIER_NAMES, LoadingMode, TierName
 from bvidfe.core.geometry import PanelGeometry
 from bvidfe.core.material import OrthotropicMaterial
 from bvidfe.damage.state import DamageState
 from bvidfe.impact.mapping import ImpactEvent
+
+
+def _validate_choice(value: object, allowed: Iterable[str], field: str) -> None:
+    """Raise ``ValueError`` if *value* is not a member of *allowed*.
+
+    The error message lists the allowed values (sorted for deterministic
+    output) and the offending value, prefixed with the *field* name, e.g.
+    ``'tier must be one of [...]; got "fe3D"'``.
+    """
+    allowed_sorted = sorted(allowed)
+    if value not in allowed_sorted:
+        raise ValueError(f"{field} must be one of {allowed_sorted}; got {value!r}")
 
 
 @dataclass
@@ -75,13 +88,15 @@ class AnalysisConfig:
     layup_deg: List[float]
     ply_thickness_mm: Union[float, Sequence[float]]
     panel: PanelGeometry
-    loading: Literal["compression", "tension"] = "compression"
-    tier: Literal["empirical", "semi_analytical", "fe3d"] = "empirical"
+    loading: LoadingMode = "compression"
+    tier: TierName = "empirical"
     impact: Optional[ImpactEvent] = None
     damage: Optional[DamageState] = None
     mesh: Optional[MeshParams] = None
 
     def __post_init__(self) -> None:
+        _validate_choice(self.tier, _TIER_NAMES, "tier")
+        _validate_choice(self.loading, _LOADING_MODES, "loading")
         if (self.impact is None) == (self.damage is None):
             raise ValueError(
                 "Provide exactly one of AnalysisConfig.impact or AnalysisConfig.damage"

--- a/tests/analysis/test_config_validation.py
+++ b/tests/analysis/test_config_validation.py
@@ -1,0 +1,77 @@
+"""Validation tests for :class:`bvidfe.analysis.config.AnalysisConfig`.
+
+Covers the ``tier`` and ``loading`` ``Literal`` aliases added in #82: every
+valid combination should construct cleanly, while every invalid string must
+raise ``ValueError`` whose message names the offending field.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+from bvidfe._types import _LOADING_MODES, _TIER_NAMES
+from bvidfe.analysis.config import AnalysisConfig, MeshParams
+from bvidfe.core.geometry import ImpactorGeometry, PanelGeometry
+from bvidfe.impact.mapping import ImpactEvent
+
+
+def _base_kwargs() -> dict:
+    """Minimum kwargs to build a valid :class:`AnalysisConfig`."""
+    return dict(
+        material="IM7/8552",
+        layup_deg=[0, 90, 0, 90],
+        ply_thickness_mm=0.2,
+        panel=PanelGeometry(10.0, 5.0),
+        impact=ImpactEvent(5.0, ImpactorGeometry(), mass_kg=5.5),
+    )
+
+
+@pytest.mark.parametrize(
+    "tier,loading",
+    list(itertools.product(sorted(_TIER_NAMES), sorted(_LOADING_MODES))),
+)
+def test_valid_tier_and_loading_combinations_construct(tier: str, loading: str) -> None:
+    kwargs = _base_kwargs()
+    kwargs["tier"] = tier
+    kwargs["loading"] = loading
+    # fe3d requires a mesh, which __post_init__ supplies via default; ensure
+    # explicit construction also works.
+    if tier == "fe3d":
+        kwargs["mesh"] = MeshParams()
+    cfg = AnalysisConfig(**kwargs)
+    assert cfg.tier == tier
+    assert cfg.loading == loading
+
+
+@pytest.mark.parametrize("bad_tier", ["fe3D", "FE3D", "empirical ", "", "fea", "fe3d_extra"])
+def test_invalid_tier_raises_value_error_with_field_name(bad_tier: str) -> None:
+    kwargs = _base_kwargs()
+    kwargs["tier"] = bad_tier
+    with pytest.raises(ValueError) as excinfo:
+        AnalysisConfig(**kwargs)
+    msg = str(excinfo.value)
+    assert "tier" in msg
+    assert repr(bad_tier) in msg
+
+
+@pytest.mark.parametrize("bad_loading", ["bending", "Compression", "TENSION", "", "compression "])
+def test_invalid_loading_raises_value_error_with_field_name(bad_loading: str) -> None:
+    kwargs = _base_kwargs()
+    kwargs["loading"] = bad_loading
+    with pytest.raises(ValueError) as excinfo:
+        AnalysisConfig(**kwargs)
+    msg = str(excinfo.value)
+    assert "loading" in msg
+    assert repr(bad_loading) in msg
+
+
+def test_invalid_tier_error_message_lists_allowed_values() -> None:
+    kwargs = _base_kwargs()
+    kwargs["tier"] = "fe3D"
+    with pytest.raises(ValueError) as excinfo:
+        AnalysisConfig(**kwargs)
+    msg = str(excinfo.value)
+    for allowed in _TIER_NAMES:
+        assert allowed in msg


### PR DESCRIPTION
Partially addresses #82 — scoped to **type-alias definitions + `AnalysisConfig` validation only**. Caller wiring (in `bvid.py`, `fe_tier.py`, `evaluator.py`) is deferred to follow-up PRs so this can land in parallel with #83 and #84.

## Summary
- New `src/bvidfe/_types.py` exporting `TierName`, `LoadingMode`, `CriterionName` `Literal` aliases plus `_TIER_NAMES`, `_LOADING_MODES`, `_CRITERION_NAMES` frozensets for runtime validation.
- `src/bvidfe/analysis/config.py`: `AnalysisConfig.tier` and `.loading` are re-annotated with the new aliases. `__post_init__` calls a `_validate_choice(value, allowed, field)` helper that raises `ValueError` with messages like `tier must be one of ['empirical', 'fe3d', 'semi_analytical']; got 'fe3D'`.
- 18 new parametrised cases in `tests/analysis/test_config_validation.py` cover every valid `tier × loading` combo and a range of invalid strings.

`CriterionName` is duplicated in `_types.py` rather than removed from `failure/evaluator.py` — the future #84-wiring PR will consolidate.

## Test plan
- [x] `pytest -x` → 391 passed, no regressions
- [x] `black src tests` + `ruff check` clean
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTG1A1VE1zUzrF8TQM8Dxe)_