### PR TITLE
API: parametrize FE3D failure criterion and dispatch `FailureEvaluator` via a registry (#84)

### DIFF
--- a/src/bvidfe/analysis/fe_tier.py
+++ b/src/bvidfe/analysis/fe_tier.py
@@ -19,6 +19,7 @@ from bvidfe.analysis.fe_mesh import FeMesh, build_fe_mesh, estimate_fe_mesh_size
 from bvidfe.core.laminate import Laminate
 from bvidfe.damage.state import DamageState
 from bvidfe.elements.hex8 import Hex8Element, build_geometry_table
+from bvidfe.failure.evaluator import CriterionName
 from bvidfe.failure.larc05 import larc05_index, larc05_index_batch
 from bvidfe.failure.tsai_wu import tsai_wu_index, tsai_wu_index_batch
 from bvidfe.solver.assembler import assemble_coo, assemble_global_stiffness
@@ -213,7 +214,7 @@ def _solve_failure_strain_analytic(
     mesh: FeMesh,
     elements: List[Hex8Element],
     strain_sign: int,
-    criterion: str,
+    criterion: CriterionName,
     strain_cap: float = 0.05,
 ) -> float:
     """Find the applied strain magnitude at which max failure index hits 1,
@@ -304,7 +305,7 @@ def _solve_failure_strain_analytic_scalar_ref(
     mesh: FeMesh,
     elements: List[Hex8Element],
     strain_sign: int,
-    criterion: str,
+    criterion: CriterionName,
     strain_cap: float = 0.05,
 ) -> float:
     """Reference (pre-vectorisation) scalar implementation of
@@ -369,11 +370,14 @@ def _fe3d_cai_first_ply_failure(
     damage: DamageState,
     lam: Laminate,
     sigma_pristine_MPa: float,
+    criterion: CriterionName = "larc05",
 ) -> float:
     """3D FE compression-after-impact residual strength via first-ply-failure (MPa).
 
-    Original v0.1.0 implementation — bisects on applied strain until LaRC05 failure
-    index reaches 1 on the damaged mesh. Retained as fallback / comparison path.
+    Original v0.1.0 implementation — bisects on applied strain until the selected
+    failure criterion's index reaches 1 on the damaged mesh. Retained as
+    fallback / comparison path. Default ``criterion="larc05"`` preserves the
+    historical behaviour; pass ``"tsai_wu"`` to use the polynomial criterion.
     """
     mesh, elements, t0 = _fe3d_preflight(cfg, damage, lam, label="fe3d FPF")
     strain_at_failure = _solve_failure_strain_analytic(
@@ -381,7 +385,7 @@ def _fe3d_cai_first_ply_failure(
         mesh,
         elements,
         strain_sign=-1,
-        criterion="larc05",
+        criterion=criterion,
     )
     _t("FPF analytic solve done", t0)
     E = _effective_modulus(lam)

--- a/src/bvidfe/failure/evaluator.py
+++ b/src/bvidfe/failure/evaluator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import Callable, Literal
 
 import numpy as np
 
@@ -12,6 +12,25 @@ from bvidfe.failure.larc05 import larc05_index, larc05_index_batch
 from bvidfe.failure.tsai_wu import tsai_wu_index, tsai_wu_index_batch
 
 CriterionName = Literal["tsai_wu", "larc05"]
+
+# Registry mapping criterion name → batch index function. New criteria are
+# added by extending this dict (and the ``CriterionName`` Literal) rather
+# than by adding another string-comparison branch in the evaluator.
+_CRITERION_REGISTRY: dict[
+    CriterionName, Callable[[OrthotropicMaterial, np.ndarray], np.ndarray]
+] = {
+    "tsai_wu": tsai_wu_index_batch,
+    "larc05": larc05_index_batch,
+}
+
+# Scalar variants used by ``FailureEvaluator._index`` (per-point evaluation).
+# Kept parallel to ``_CRITERION_REGISTRY`` so any extension touches both.
+_CRITERION_SCALAR_REGISTRY: dict[
+    CriterionName, Callable[[OrthotropicMaterial, np.ndarray], float]
+] = {
+    "tsai_wu": tsai_wu_index,
+    "larc05": larc05_index,
+}
 
 
 @dataclass
@@ -28,20 +47,21 @@ class FailureEvaluator:
     """Applies a failure criterion across every (element, gauss-point) stress."""
 
     def __init__(self, material: OrthotropicMaterial, criterion: CriterionName = "tsai_wu"):
-        if criterion not in ("tsai_wu", "larc05"):
-            raise ValueError(f"unknown criterion {criterion!r}")
+        if criterion not in _CRITERION_REGISTRY:
+            valid = sorted(_CRITERION_REGISTRY.keys())
+            raise ValueError(f"unknown criterion {criterion!r}; valid options are {valid}")
         self.material = material
         self.criterion = criterion
+        # Cache function pointers at construction time so ``evaluate`` and
+        # ``_index`` no longer branch on raw strings.
+        self._evaluate_fn = _CRITERION_REGISTRY[criterion]
+        self._scalar_fn = _CRITERION_SCALAR_REGISTRY[criterion]
 
     def _index(self, stress):
-        if self.criterion == "tsai_wu":
-            return tsai_wu_index(self.material, stress)
-        return larc05_index(self.material, stress)
+        return self._scalar_fn(self.material, stress)
 
     def _index_batch(self, stresses: np.ndarray) -> np.ndarray:
-        if self.criterion == "tsai_wu":
-            return tsai_wu_index_batch(self.material, stresses)
-        return larc05_index_batch(self.material, stresses)
+        return self._evaluate_fn(self.material, stresses)
 
     def evaluate(self, stress_field: np.ndarray) -> LaminateFailureReport:
         """Return the highest failure index across an (n_elem, n_gp, 6) field.

--- a/tests/analysis/test_fe_tier.py
+++ b/tests/analysis/test_fe_tier.py
@@ -1,7 +1,12 @@
 import pytest
 
 from bvidfe.analysis.config import AnalysisConfig, MeshParams
-from bvidfe.analysis.fe_tier import FE3DSizeError, fe3d_cai, fe3d_tai
+from bvidfe.analysis.fe_tier import (
+    FE3DSizeError,
+    _fe3d_cai_first_ply_failure,
+    fe3d_cai,
+    fe3d_tai,
+)
 from bvidfe.core.geometry import ImpactorGeometry, PanelGeometry
 from bvidfe.core.laminate import Laminate
 from bvidfe.core.material import MATERIAL_LIBRARY
@@ -69,3 +74,22 @@ def test_fe3d_rejects_oversized_mesh():
         fe3d_cai(oversized_cfg, DamageState([], 0.0), lam, 500.0)
     with pytest.raises(FE3DSizeError):
         fe3d_tai(oversized_cfg, DamageState([], 0.0), lam, 800.0)
+
+
+def test_fe3d_fpf_accepts_explicit_criterion(small_cfg):
+    """``_fe3d_cai_first_ply_failure`` must accept ``criterion="tsai_wu"``
+    instead of hardcoding LaRC05. The default behaviour (no kwarg) stays
+    LaRC05 — verified by comparing the explicit-larc05 call against the
+    default call.
+    """
+    lam = Laminate(MATERIAL_LIBRARY["IM7/8552"], small_cfg.layup_deg, small_cfg.ply_thickness_mm)
+    damage = DamageState([], dent_depth_mm=0.0)
+
+    sigma_default = _fe3d_cai_first_ply_failure(small_cfg, damage, lam, 500.0)
+    sigma_larc05 = _fe3d_cai_first_ply_failure(small_cfg, damage, lam, 500.0, criterion="larc05")
+    sigma_tsai = _fe3d_cai_first_ply_failure(small_cfg, damage, lam, 500.0, criterion="tsai_wu")
+
+    # Default must match explicit larc05 (preserves prior behaviour).
+    assert sigma_default == pytest.approx(sigma_larc05, rel=1e-12)
+    # All paths return positive residual strength on a pristine panel.
+    assert sigma_tsai > 0

--- a/tests/failure/test_evaluator.py
+++ b/tests/failure/test_evaluator.py
@@ -40,6 +40,40 @@ def test_evaluator_unknown_criterion_raises():
         FailureEvaluator(m, criterion="bogus")
 
 
+def test_criterion_registry_contains_known_keys():
+    """The registry is the single source of truth for available criteria;
+    asserting its keys here pins the supported set so any future addition
+    has to update this test deliberately."""
+    from bvidfe.failure.evaluator import _CRITERION_REGISTRY
+
+    assert set(_CRITERION_REGISTRY.keys()) == {"tsai_wu", "larc05"}
+
+
+def test_evaluator_unknown_criterion_error_lists_valid_names():
+    """The ValueError raised on bad input must name every valid criterion
+    so users get an actionable message instead of a bare 'unknown
+    criterion' string."""
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    with pytest.raises(ValueError) as excinfo:
+        FailureEvaluator(m, criterion="bogus")
+    msg = str(excinfo.value)
+    assert "tsai_wu" in msg
+    assert "larc05" in msg
+
+
+def test_evaluator_caches_function_pointer():
+    """``__init__`` must store the dispatch function on ``self`` so
+    ``evaluate`` no longer branches on raw strings."""
+    from bvidfe.failure.larc05 import larc05_index_batch
+    from bvidfe.failure.tsai_wu import tsai_wu_index_batch
+
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    ev_tw = FailureEvaluator(m, criterion="tsai_wu")
+    ev_lc = FailureEvaluator(m, criterion="larc05")
+    assert ev_tw._evaluate_fn is tsai_wu_index_batch
+    assert ev_lc._evaluate_fn is larc05_index_batch
+
+
 def test_evaluate_matches_scalar_loop():
     """Lock the vectorised FailureEvaluator.evaluate against the prior
     nested-Python-loop form on a random (3, 4, 6) stress field. Tsai-Wu


### PR DESCRIPTION
Closes #84.

## Summary

**`src/bvidfe/failure/evaluator.py`** — replaces string-branched dispatch with a registry:

```python
_CRITERION_REGISTRY: dict[CriterionName, Callable[..., np.ndarray]] = {
    "tsai_wu": tsai_wu_index_batch,
    "larc05":  larc05_index_batch,
}
_CRITERION_SCALAR_REGISTRY: dict[CriterionName, Callable[..., float]] = {...}
```

`FailureEvaluator.__init__` validates the criterion against `_CRITERION_REGISTRY` (raises `ValueError` listing both valid keys on bad input) and caches `self._evaluate_fn` / `self._scalar_fn`. `evaluate` / `_index` / `_index_batch` now call the cached function pointer — no string compares on the hot path.

**`src/bvidfe/analysis/fe_tier.py`** — adds `criterion: CriterionName = "larc05"` to `_fe3d_cai_first_ply_failure` and threads it through `_solve_failure_strain_analytic`. Default preserves the existing behaviour; users and tests can now flip criterion without monkey-patching.

## Tests added
- Registry contains both keys; pointers match the registry entries.
- `FailureEvaluator("bogus")` raises `ValueError` with `"tsai_wu"` AND `"larc05"` in the message.
- `_fe3d_cai_first_ply_failure` accepts explicit `criterion="tsai_wu"`; default `"larc05"` produces the same output as explicit `"larc05"`.

## Test plan
- [x] `pytest -x` → 377 passed
- [x] `black --check` + `ruff check` clean
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTG1A1VE1zUzrF8TQM8Dxe)_