### PR TITLE
Docs: publish MkDocs Material site + auto-generated JSON Schemas (#93)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,53 @@
+name: docs
+
+# Build and deploy the MkDocs site to GitHub Pages on every push to main.
+# We deliberately do NOT trigger on pull_request to avoid burning CI minutes
+# on draft PRs — preview builds (if ever wanted) should go through a manual
+# workflow_dispatch.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Required by actions/deploy-pages (OIDC + pages write).
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Avoid concurrent deploys racing each other.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install docs dependencies
+        run: pip install ".[docs]"
+
+      - name: Build site (strict mode)
+        run: mkdocs build --strict
+
+      - name: Upload artifact for Pages
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,9 @@ examples/output/*.png
 examples/output/*.csv
 examples/output/*.json
 
+# Local MkDocs build output (CI rebuilds and deploys to GitHub Pages).
+site/
+
 # ---- Claude Code / superpowers / subagent outputs ----
 docs/superpowers/
 .superpowers/

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ type: software
 title: "BVID-FE: Barely Visible Impact Damage residual-strength analysis for composite laminates"
 version: 0.1.0
 date-released: 2026-04-17
-url: "https://github.com/elhajjar1/BVID-FE"
+url: "https://ranipdx-glitch.github.io/BVID-FE/"
 repository-code: "https://github.com/elhajjar1/BVID-FE"
 license: MIT
 authors:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![Tests](https://github.com/ranipdx-glitch/BVID-FE/actions/workflows/tests.yml/badge.svg)](https://github.com/ranipdx-glitch/BVID-FE/actions/workflows/tests.yml)
+[![Docs](https://img.shields.io/badge/docs-mkdocs--material-blue)](https://ranipdx-glitch.github.io/BVID-FE/)
+
+> **Documentation:** the full MkDocs site is published at
+> <https://ranipdx-glitch.github.io/BVID-FE/> and includes a Quickstart, the
+> Python API reference, the C-scan JSON schema, the physics models, and the
+> Streamlit deployment guide. Auto-generated JSON Schemas for `AnalysisConfig`
+> and `AnalysisResults` live at
+> [`/schemas/`](https://ranipdx-glitch.github.io/BVID-FE/schemas/analysis_config.json).
 
 A Python library for predicting residual strength and stiffness of fiber-reinforced composite laminates containing Barely Visible Impact Damage (BVID).
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,71 @@
+# Deployment
+
+BVID-FE ships with a Streamlit web app (`app.py`) that wraps
+`bvidfe.analysis.BvidAnalysis`. This page summarises how to publish a public
+URL on Streamlit Community Cloud — the full guide lives in
+[`DEPLOYMENT_STREAMLIT.md`](https://github.com/ranipdx-glitch/BVID-FE/blob/main/DEPLOYMENT_STREAMLIT.md).
+
+## Local smoke test
+
+```bash
+pip install -r requirements.txt
+pip install -e .
+streamlit run app.py
+```
+
+A browser tab should open at <http://localhost:8501>. Tweak parameters in
+the sidebar, click **Run analysis**, and verify the **Results** tabs
+populate.
+
+## Streamlit Community Cloud
+
+1. Push your branch (typically `main`) to GitHub.
+2. Sign in at <https://share.streamlit.io> with the GitHub account that owns
+   the repo (`ranipdx-glitch`).
+3. **Create app** → **Deploy a public app from GitHub**:
+    - **Repository:** `ranipdx-glitch/BVID-FE`
+    - **Branch:** `main`
+    - **Main file path:** `app.py`
+    - **App URL:** pick a sub-domain (e.g. `bvidfe.streamlit.app`)
+4. In **Advanced settings** set Python to **3.11**.
+5. Click **Deploy**. First build takes 2–4 minutes; subsequent redeploys
+   finish in ~30 s.
+
+Every push to the configured branch triggers an automatic redeploy.
+
+## Resource limits
+
+Streamlit Cloud (Community tier) provisions per app:
+
+- 1 GB RAM
+- 1 vCPU
+- shared, ephemeral filesystem
+- no GPU
+- public repos only by default
+
+Implications for BVID-FE:
+
+- The **fe3d** tier solves a 3D FE problem and can easily blow past 1 GB
+  on dense meshes. The Streamlit app defaults to **empirical** and warns
+  before launching fe3d. If you allow fe3d in the cloud, keep
+  `elements_per_ply = 1` and `in_plane_size_mm >= 5`.
+- Don't write user-supplied data anywhere except `tempfile`-scoped paths;
+  the filesystem resets on every reboot.
+
+## Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| Build fails on `PyQt6` / `pyvista` | They should not be in `requirements.txt`. Streamlit Cloud has no display server. |
+| App boots but `import bvidfe` fails | Confirm the package installs from source: `pip install -e .` works locally. |
+| Plots don't render | Make sure `matplotlib.use("Agg")` is called before any `pyplot` import. `app.py` already does this. |
+| Slow first run | Expected — numpy/scipy/shapely wheels are ~100 MB combined. |
+| Out of memory on large fe3d run | Increase `in_plane_size_mm`, keep `elements_per_ply = 1`, or switch to the empirical / semi_analytical tier. |
+| `FE3DSizeError` | The mesh exceeds `BVIDFE_FE3D_MAX_DOF`. Coarsen the mesh — Streamlit Cloud doesn't have the headroom to raise this cap. |
+
+## Optional next steps
+
+- Add a `runtime.txt` with `python-3.11` to pin the Python version exactly.
+- Configure a custom domain in Streamlit Cloud's settings.
+- Add Streamlit secrets via the Manage panel if the app later needs API keys.
+- Add CI to run `streamlit run --headless` smoke tests on every PR.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,86 @@
+# BVID-FE
+
+A Python library for predicting residual strength and stiffness of fiber-reinforced composite laminates containing Barely Visible Impact Damage (BVID).
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
+[![Tests](https://github.com/ranipdx-glitch/BVID-FE/actions/workflows/tests.yml/badge.svg)](https://github.com/ranipdx-glitch/BVID-FE/actions/workflows/tests.yml)
+
+## Why this tool?
+
+Low-velocity impacts on composite structures can create internal delaminations
+that are invisible to the naked eye yet significantly degrade compression and
+tension strength. Engineers certifying composite airframes and pressure vessels
+need fast, reliable estimates of how much strength is lost and how the
+knockdown depends on layup, panel size, and impact energy. BVID-FE provides
+three modeling tiers — from a 30-millisecond empirical lookup to a full 3D
+finite-element solution — so the right level of fidelity can be chosen for
+each stage of the design process.
+
+BVID-FE is the third in a family of defect-specific composite tools, joining
+**PorosityFE** (porosity defects) and **WrinkleFE** (fiber waviness). The three
+tools share material models, laminate theory, failure criteria, and
+documentation conventions.
+
+## Features
+
+- **Two workflow paths** converging on a shared `DamageState`:
+    - *Impact-driven*: Olsson quasi-static threshold + peanut-template DPA
+      distribution + empirical dent model
+    - *Inspection-driven*: C-scan JSON import per the documented schema
+      (see [C-Scan Schema](cscan_schema.md))
+- **Three modeling tiers** for residual strength after BVID:
+    - *Empirical*: Soutis CAI knockdown + Whitney-Nuismer TAI (seconds)
+    - *Semi-analytical*: Rayleigh-Ritz sublaminate buckling + Soutis
+      post-buckling envelope; Whitney-Nuismer for TAI (seconds)
+    - *3D FE*: First-ply-failure on a damaged hexahedral mesh; LaRC05 for
+      CAI, Tsai-Wu for TAI (minutes)
+- **CAI and TAI loading modes** (Compression-After-Impact and
+  Tension-After-Impact)
+- **Per-interface ellipse damage model** using `DelaminationEllipse` with
+  shapely-union projected damage area
+- **Four material presets**: AS4/3501-6, IM7/8552, T700/2510, T800/epoxy
+- **CLI**, **Streamlit web app**, and **Python API**
+- **Parametric sweeps** over impact energy, layup, or ply thickness with
+  CSV output
+- **2D / 3D visualisations** of damage and stress fields
+
+## Installation
+
+```bash
+git clone https://github.com/ranipdx-glitch/BVID-FE.git
+cd BVID-FE
+pip install -e ".[dev]"
+pytest -v
+```
+
+## Where to next
+
+- [Quickstart](quickstart.md) — run your first analysis in under a minute.
+- [Python API](python_api.md) — script BVID-FE workflows beyond the GUI/CLI.
+- [C-Scan Schema](cscan_schema.md) — load inspection data from JSON.
+- [Physics Models](physics_models.md) — what each tier solves.
+- [Deployment](deployment.md) — publish the Streamlit app to a public URL.
+
+## JSON Schemas
+
+Auto-generated JSON Schemas (draft 2020-12) for the public data contracts are
+published with this site:
+
+- [`analysis_config.json`](schemas/analysis_config.json) — `AnalysisConfig`
+- [`analysis_results.json`](schemas/analysis_results.json) — `AnalysisResults`
+
+The schemas are regenerated from the in-tree dataclasses by
+`scripts/generate_schemas.py`.
+
+## Citation
+
+If you use BVID-FE in your research, please cite the project (see the
+[CITATION.cff](https://github.com/ranipdx-glitch/BVID-FE/blob/main/CITATION.cff)
+at the repository root).
+
+## License
+
+MIT License. See
+[LICENSE](https://github.com/ranipdx-glitch/BVID-FE/blob/main/LICENSE) for
+details.

--- a/docs/physics_models.md
+++ b/docs/physics_models.md
@@ -1,0 +1,113 @@
+# Physics Models
+
+BVID-FE exposes three residual-strength modeling tiers that share a common
+data contract (`DamageState` → tier engine → `AnalysisResults`) but differ in
+fidelity, runtime, and the failure mechanisms they capture. This page
+summarises what each tier solves; see the
+[Python API reference](python_api.md) for usage.
+
+## Empirical tier
+
+Soutis open-hole-equivalent CAI model relates the delamination-affected stress
+concentration around the projected damage area to a net-section failure.
+Whitney-Nuismer point-stress and average-stress criteria are used for TAI.
+Both models are closed-form and run in milliseconds.
+
+## Semi-analytical tier
+
+The damaged sublaminate above the largest delamination is treated as a plate
+with reduced in-plane stiffness. A Rayleigh-Ritz energy method solves for the
+sublaminate buckling load, and the Soutis post-buckling envelope predicts the
+far-field CAI stress at overall failure. Whitney-Nuismer is retained for TAI.
+Sublaminate eigenvalues are available in `AnalysisResults.buckling_eigenvalues`.
+
+## 3D FE tier
+
+A structured hexahedral mesh is built for the damaged laminate. Delaminated
+interfaces are approximated by a **component-wise stiffness-reduction model**
+(true cohesive surfaces deferred to a future release): each damaged element
+carries an out-of-plane factor (`DAMAGE_OOP_FACTOR ≈ 0.05`) that scales the
+through-thickness and transverse-shear stiffness, while in-plane stiffness is
+preserved (the plies themselves remain intact). Inside the fiber-break core
+under the impact site, in-plane stiffness is also reduced
+(`DAMAGE_FIBER_BREAK_INPLANE_FACTOR ≈ 0.30`) to represent fiber bundle
+fracture. First-ply-failure is evaluated at all Gauss points using LaRC05
+(CAI) and Tsai-Wu (TAI). For CAI, a true linear buckling eigensolve runs
+alongside FPF and the lower of the two governs.
+
+## Knockdown definition and cross-tier comparability
+
+`AnalysisResults.knockdown` is computed in exactly one place —
+`BvidAnalysis.run()` (`src/bvidfe/analysis/bvid.py`):
+
+```python
+knockdown = residual_strength_MPa / pristine_strength_MPa
+```
+
+**The denominator is identical across all three tiers.**
+`_pristine_strength()` is a thickness-weighted ply-average of the
+lamina-level strengths from the material card:
+
+- CAI: `Σ tᵢ (Xc·cos²θᵢ + Yc·sin²θᵢ) / Σ tᵢ`
+- TAI: `Σ tᵢ (Xt·cos²θᵢ + Yt·sin²θᵢ) / Σ tᵢ`
+
+**The numerator (residual strength) is what differs between tiers:**
+
+| Tier | CAI residual stress | TAI residual stress |
+| --- | --- | --- |
+| `empirical` | Soutis: `σ₀ / (1 + k_s·(DPA/A_panel)^m)` | Whitney-Nuismer point-stress on equivalent hole |
+| `semi_analytical` | `min(Soutis, σ_buckling_sublam)` | Delegates to Whitney-Nuismer (identical to `empirical`) |
+| `fe3d` | `min(λ_crit·σ_ref, FPF_LaRC05)`, capped at σ₀ | FPF Tsai-Wu on damaged mesh, capped at σ₀ |
+
+**What this means for users:**
+
+- All three tiers report knockdown on the **same scale** (ratio relative to
+  the same pristine baseline), so values are *qualitatively comparable*.
+- They are **not** numerically interchangeable: each tier captures
+  different failure mechanisms.
+    - For **TAI**, `empirical` and `semi_analytical` are mathematically
+      identical; `fe3d` differs.
+    - For **CAI**, `semi_analytical ≤ empirical` always (the buckling floor
+      only lowers the residual). `fe3d` is independent and dominated by
+      stress concentration at the damage boundary rather than damage
+      magnitude — see "Limitations" below.
+- For **energy-scaling studies**, prefer `empirical` (Soutis scales with
+  DPA) or `semi_analytical` (Rayleigh-Ritz scales with ellipse size).
+  `fe3d` is intended for stress-field context and through-thickness damage
+  visualization, not energy-dependent knockdown curves.
+
+## Limitations
+
+- Material calibration constants (`olsson_alpha`, `soutis_k_s`, `dent_beta`,
+  and related parameters) are reasonable defaults for typical CFRP systems.
+  Precise values need calibration against material-specific coupon test data
+  before use in certification.
+- LaRC05 is implemented as a minimal Hashin-3D reduction. Full plane-search
+  fiber-kinking is deferred to a future release.
+- The `fe3d` tier uses component-wise stiffness reduction at delaminated
+  interfaces (in-plane preserved, out-of-plane reduced) instead of true
+  cohesive surfaces with bilinear traction-separation laws. Cohesive surfaces
+  are deferred to a future release.
+- **The `fe3d` tier's knockdown is partially insensitive to impact energy**
+  above the Olsson threshold. Linear buckling now responds to delamination
+  size, but the FPF fallback strain is controlled by stress concentration
+  at the healthy/damaged boundary rather than damage magnitude. For
+  energy-dependent knockdown curves prefer `tier="empirical"` or
+  `tier="semi_analytical"`. Full energy-monotonicity (in-plane pre-stress
+  BCs + cohesive surfaces) is v0.3.0 scope.
+- No validated datasets included; comparison against published Soutis,
+  Caprino, and NASA datasets is on the roadmap.
+
+## References
+
+- Olsson, R. (2001). Analytical prediction of large mass impact damage in
+  composite laminates. *Composites Part A*, 32(9), 1207-1215.
+- Soutis, C. (1996). Compressive strength of unidirectional composites:
+  measurement and prediction. *ASTM STP*, 1242, 168-176.
+- Whitney, J.M. & Nuismer, R.J. (1974). Stress fracture criteria for
+  laminated composites containing stress concentrations.
+  *Journal of Composite Materials*, 8(3), 253-265.
+- Tsai, S.W. & Wu, E.M. (1971). A general theory of strength for anisotropic
+  materials. *Journal of Composite Materials*, 5(1), 58-80.
+- Davila, C.G., Camanho, P.P., & Rose, C.A. (2005). Failure criteria for FRP
+  laminates. NASA/TM-2005-213530 (LaRC05).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,103 @@
+# Quickstart
+
+The fastest path from a fresh clone to a residual-strength estimate.
+
+## 1. Install
+
+```bash
+git clone https://github.com/ranipdx-glitch/BVID-FE.git
+cd BVID-FE
+pip install -e ".[dev]"
+```
+
+To also build this documentation site locally, install the `docs` extras:
+
+```bash
+pip install -e ".[docs]"
+mkdocs serve     # http://127.0.0.1:8000
+```
+
+## 2. Try it in Jupyter
+
+The fastest tour of the physics is
+[`examples/quickstart.ipynb`](https://github.com/ranipdx-glitch/BVID-FE/blob/main/examples/quickstart.ipynb)
+— a runnable notebook that walks through:
+
+- the Olsson quasi-static damage threshold,
+- the peanut-template DPA distribution across ply interfaces,
+- the Soutis CAI knockdown formula,
+- the Whitney-Nuismer TAI point-stress criterion,
+
+with LaTeX derivations and inline Plotly damage map / knockdown sweep / 3D
+damage mesh visualisations.
+
+```bash
+pip install jupyter
+jupyter notebook examples/quickstart.ipynb
+```
+
+## 3. Run from Python
+
+```python
+from bvidfe.analysis import AnalysisConfig, BvidAnalysis
+from bvidfe.core.geometry import PanelGeometry, ImpactorGeometry
+from bvidfe.impact.mapping import ImpactEvent
+
+cfg = AnalysisConfig(
+    material="IM7/8552",
+    layup_deg=[0, 45, -45, 90] * 4,
+    ply_thickness_mm=0.152,
+    panel=PanelGeometry(Lx_mm=150, Ly_mm=100),
+    impact=ImpactEvent(
+        energy_J=30,
+        impactor=ImpactorGeometry(diameter_mm=16),
+        mass_kg=5.5,
+    ),
+    loading="compression",
+    tier="semi_analytical",
+)
+result = BvidAnalysis(cfg).run()
+print(result.summary())
+```
+
+## 4. Run from the command line
+
+```bash
+bvidfe --material IM7/8552 \
+       --layup "0,45,-45,90,90,-45,45,0" \
+       --thickness 0.152 \
+       --panel 150x100 \
+       --loading compression \
+       --energy 30
+```
+
+All lengths are in **millimetres**. `--panel` is `<Lx>x<Ly>` (literal `x`
+separator, no spaces — e.g. `150x100` is `Lx = 150` mm, `Ly = 100` mm).
+`--thickness` is the per-ply thickness in mm; `--layup` is a comma-separated
+list of ply angles in degrees; `--energy` is the impact energy in joules.
+
+## 5. Streamlit web app
+
+```bash
+streamlit run app.py
+```
+
+Opens the BVID-FE web UI at <http://localhost:8501>. Configure the material,
+layup, panel, impact (or C-scan), pick a tier, click **Run analysis**. Results
+appear across the Summary / Damage Map / 3D Damage / Knockdown / Buckling /
+Damage Severity / Sweep tabs.
+
+See [Deployment](deployment.md) for publishing this app to a public URL on
+Streamlit Community Cloud.
+
+## More examples
+
+The repository's [`examples/`](https://github.com/ranipdx-glitch/BVID-FE/tree/main/examples)
+folder contains five end-to-end scripts:
+
+- `01_empirical_quick.py` — minimal one-shot empirical analysis.
+- `02_tier_comparison.py` — all three tiers on the same damage state.
+- `03_energy_sweep.py` — parametric sweep + plot.
+- `04_inspection_driven.py` — C-scan JSON loading.
+- `05_tier_comparison_sweep.py` — empirical vs. semi-analytical across
+  impact energies.

--- a/docs/schemas/analysis_config.json
+++ b/docs/schemas/analysis_config.json
@@ -1,0 +1,363 @@
+{
+  "$defs": {
+    "DamageState": {
+      "additionalProperties": false,
+      "description": "Full BVID damage description handed between impact mapping and solvers.",
+      "properties": {
+        "delaminations": {
+          "items": {
+            "$ref": "#/$defs/DelaminationEllipse"
+          },
+          "type": "array"
+        },
+        "dent_depth_mm": {
+          "type": "number"
+        },
+        "fiber_break_radius_mm": {
+          "type": "number"
+        }
+      },
+      "title": "DamageState",
+      "type": "object"
+    },
+    "DelaminationEllipse": {
+      "additionalProperties": false,
+      "description": "A single delamination at a specific ply interface, in the panel XY frame.",
+      "properties": {
+        "centroid_mm": {
+          "maxItems": 2,
+          "minItems": 2,
+          "prefixItems": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "type": "array"
+        },
+        "interface_index": {
+          "type": "integer"
+        },
+        "major_mm": {
+          "type": "number"
+        },
+        "minor_mm": {
+          "type": "number"
+        },
+        "orientation_deg": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "interface_index",
+        "centroid_mm",
+        "major_mm",
+        "minor_mm",
+        "orientation_deg"
+      ],
+      "title": "DelaminationEllipse",
+      "type": "object"
+    },
+    "ImpactEvent": {
+      "additionalProperties": false,
+      "description": "Parameters describing a single impact event.",
+      "properties": {
+        "energy_J": {
+          "type": "number"
+        },
+        "impactor": {
+          "$ref": "#/$defs/ImpactorGeometry"
+        },
+        "location_xy_mm": {
+          "maxItems": 2,
+          "minItems": 2,
+          "prefixItems": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "type": "array"
+        },
+        "mass_kg": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "energy_J"
+      ],
+      "title": "ImpactEvent",
+      "type": "object"
+    },
+    "ImpactorGeometry": {
+      "additionalProperties": false,
+      "description": "Impactor used in a simulated drop/impact event.",
+      "properties": {
+        "diameter_mm": {
+          "type": "number"
+        },
+        "shape": {
+          "enum": [
+            "hemispherical",
+            "flat",
+            "conical"
+          ],
+          "type": "string"
+        }
+      },
+      "title": "ImpactorGeometry",
+      "type": "object"
+    },
+    "MeshParams": {
+      "additionalProperties": false,
+      "description": "Mesh resolution parameters for the ``tier=\"fe3d\"`` solve.",
+      "properties": {
+        "cohesive_zone_factor": {
+          "type": "number"
+        },
+        "elements_per_ply": {
+          "type": "integer"
+        },
+        "in_plane_size_mm": {
+          "type": "number"
+        }
+      },
+      "title": "MeshParams",
+      "type": "object"
+    },
+    "OrthotropicMaterial": {
+      "additionalProperties": false,
+      "description": "Orthotropic composite ply material with strengths, toughnesses, and",
+      "properties": {
+        "E11": {
+          "type": "number"
+        },
+        "E22": {
+          "type": "number"
+        },
+        "G12": {
+          "type": "number"
+        },
+        "G13": {
+          "type": "number"
+        },
+        "G23": {
+          "type": "number"
+        },
+        "G_IIc": {
+          "type": "number"
+        },
+        "G_Ic": {
+          "type": "number"
+        },
+        "S12": {
+          "type": "number"
+        },
+        "S13": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "S23": {
+          "type": "number"
+        },
+        "Xc": {
+          "type": "number"
+        },
+        "Xt": {
+          "type": "number"
+        },
+        "Yc": {
+          "type": "number"
+        },
+        "Yt": {
+          "type": "number"
+        },
+        "Zc": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "Zt": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "dent_beta": {
+          "type": "number"
+        },
+        "dent_gamma": {
+          "type": "number"
+        },
+        "fiber_break_E_threshold": {
+          "type": "number"
+        },
+        "fiber_break_eta": {
+          "type": "number"
+        },
+        "name": {
+          "type": "string"
+        },
+        "nu12": {
+          "type": "number"
+        },
+        "olsson_alpha": {
+          "type": "number"
+        },
+        "rho": {
+          "type": "number"
+        },
+        "soutis_k_s": {
+          "type": "number"
+        },
+        "soutis_m": {
+          "type": "number"
+        },
+        "wn_d0_mm": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "name",
+        "E11",
+        "E22",
+        "nu12",
+        "G12",
+        "G13",
+        "G23",
+        "Xt",
+        "Xc",
+        "Yt",
+        "Yc",
+        "S12",
+        "S23",
+        "G_Ic",
+        "G_IIc",
+        "rho"
+      ],
+      "title": "OrthotropicMaterial",
+      "type": "object"
+    },
+    "PanelGeometry": {
+      "additionalProperties": false,
+      "description": "In-plane rectangular panel with boundary condition.",
+      "properties": {
+        "Lx_mm": {
+          "type": "number"
+        },
+        "Ly_mm": {
+          "type": "number"
+        },
+        "boundary": {
+          "enum": [
+            "clamped",
+            "simply_supported",
+            "free"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "Lx_mm",
+        "Ly_mm"
+      ],
+      "title": "PanelGeometry",
+      "type": "object"
+    }
+  },
+  "$id": "https://ranipdx-glitch.github.io/BVID-FE/schemas/analysis_config.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "BVID analysis configuration. Provide exactly ONE of `impact` or `damage`.",
+  "properties": {
+    "damage": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/DamageState"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "impact": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ImpactEvent"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "layup_deg": {
+      "items": {
+        "type": "number"
+      },
+      "type": "array"
+    },
+    "loading": {
+      "enum": [
+        "compression",
+        "tension"
+      ],
+      "type": "string"
+    },
+    "material": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/OrthotropicMaterial"
+        }
+      ]
+    },
+    "mesh": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/MeshParams"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "panel": {
+      "$ref": "#/$defs/PanelGeometry"
+    },
+    "ply_thickness_mm": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "description": "Unresolved annotation typing.Sequence[float]"
+        }
+      ]
+    },
+    "tier": {
+      "enum": [
+        "empirical",
+        "semi_analytical",
+        "fe3d"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "material",
+    "layup_deg",
+    "ply_thickness_mm",
+    "panel"
+  ],
+  "title": "AnalysisConfig",
+  "type": "object"
+}

--- a/docs/schemas/analysis_results.json
+++ b/docs/schemas/analysis_results.json
@@ -1,0 +1,191 @@
+{
+  "$defs": {
+    "DamageState": {
+      "additionalProperties": false,
+      "description": "Full BVID damage description handed between impact mapping and solvers.",
+      "properties": {
+        "delaminations": {
+          "items": {
+            "$ref": "#/$defs/DelaminationEllipse"
+          },
+          "type": "array"
+        },
+        "dent_depth_mm": {
+          "type": "number"
+        },
+        "fiber_break_radius_mm": {
+          "type": "number"
+        }
+      },
+      "title": "DamageState",
+      "type": "object"
+    },
+    "DelaminationEllipse": {
+      "additionalProperties": false,
+      "description": "A single delamination at a specific ply interface, in the panel XY frame.",
+      "properties": {
+        "centroid_mm": {
+          "maxItems": 2,
+          "minItems": 2,
+          "prefixItems": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "type": "array"
+        },
+        "interface_index": {
+          "type": "integer"
+        },
+        "major_mm": {
+          "type": "number"
+        },
+        "minor_mm": {
+          "type": "number"
+        },
+        "orientation_deg": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "interface_index",
+        "centroid_mm",
+        "major_mm",
+        "minor_mm",
+        "orientation_deg"
+      ],
+      "title": "DelaminationEllipse",
+      "type": "object"
+    },
+    "FieldResults": {
+      "additionalProperties": false,
+      "description": "Per-mesh field outputs reserved for the 3D FE tier.",
+      "properties": {
+        "buckling_mode_shape": {
+          "description": "numpy.ndarray (ndarray) \u2014 serialised as a nested list.",
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "cohesive_damage": {
+          "description": "numpy.ndarray (ndarray) \u2014 serialised as a nested list.",
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "displacement": {
+          "description": "numpy.ndarray (ndarray) \u2014 serialised as a nested list.",
+          "type": "array"
+        },
+        "failure_index": {
+          "description": "numpy.ndarray (ndarray) \u2014 serialised as a nested list.",
+          "type": "array"
+        },
+        "strain_global": {
+          "description": "numpy.ndarray (ndarray) \u2014 serialised as a nested list.",
+          "type": "array"
+        },
+        "stress_global": {
+          "description": "numpy.ndarray (ndarray) \u2014 serialised as a nested list.",
+          "type": "array"
+        },
+        "stress_local": {
+          "description": "numpy.ndarray (ndarray) \u2014 serialised as a nested list.",
+          "type": "array"
+        }
+      },
+      "required": [
+        "displacement",
+        "stress_global",
+        "strain_global",
+        "stress_local",
+        "failure_index"
+      ],
+      "title": "FieldResults",
+      "type": "object"
+    }
+  },
+  "$id": "https://ranipdx-glitch.github.io/BVID-FE/schemas/analysis_results.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Outcome of a single ``BvidAnalysis.run()`` invocation.",
+  "properties": {
+    "buckling_eigenvalues": {
+      "items": {
+        "type": "number"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    },
+    "config_snapshot": {
+      "additionalProperties": {
+        "description": "Python type Any (no JSON Schema mapping)"
+      },
+      "type": "object"
+    },
+    "critical_sublaminate": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "damage": {
+      "$ref": "#/$defs/DamageState"
+    },
+    "dpa_mm2": {
+      "type": "number"
+    },
+    "field_results": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/FieldResults"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "knockdown": {
+      "type": "number"
+    },
+    "notes": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "pristine_strength_MPa": {
+      "type": "number"
+    },
+    "residual_strength_MPa": {
+      "type": "number"
+    },
+    "tier_used": {
+      "type": "string"
+    },
+    "warnings": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "residual_strength_MPa",
+    "pristine_strength_MPa",
+    "knockdown",
+    "damage",
+    "dpa_mm2",
+    "tier_used",
+    "config_snapshot"
+  ],
+  "title": "AnalysisResults",
+  "type": "object"
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,78 @@
+site_name: BVID-FE
+site_description: Barely Visible Impact Damage residual-strength analysis for composite laminates
+site_url: https://ranipdx-glitch.github.io/BVID-FE/
+repo_url: https://github.com/ranipdx-glitch/BVID-FE
+repo_name: ranipdx-glitch/BVID-FE
+edit_uri: edit/main/docs/
+
+docs_dir: docs
+
+# Files inside docs/ that are internal/dev-only and should NOT ship with the
+# published site. Listed explicitly so mkdocs --strict stays quiet about
+# "pages exist in the docs directory but are not in the nav".
+exclude_docs: |
+  BUILD.md
+  superpowers/
+
+theme:
+  name: material
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - content.code.copy
+    - content.code.annotate
+    - search.suggest
+    - search.highlight
+    - toc.follow
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+nav:
+  - Home: index.md
+  - Quickstart: quickstart.md
+  - Python API: python_api.md
+  - C-Scan Schema: cscan_schema.md
+  - Physics Models: physics_models.md
+  - Deployment: deployment.md
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.tilde
+
+plugins:
+  - search

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,11 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pytest>=7,<9", "pytest-cov>=4,<7", "ruff>=0.5,<1", "black>=24,<26", "pre-commit>=3,<5"]
+docs = ["mkdocs>=1.6,<2", "mkdocs-material>=9.5,<10"]
 
 [project.urls]
 Homepage = "https://github.com/ranipdx-glitch/BVID-FE"
+Documentation = "https://ranipdx-glitch.github.io/BVID-FE/"
 Repository = "https://github.com/ranipdx-glitch/BVID-FE"
 Issues = "https://github.com/ranipdx-glitch/BVID-FE/issues"
 Changelog = "https://github.com/ranipdx-glitch/BVID-FE/blob/main/CHANGELOG.md"

--- a/scripts/generate_schemas.py
+++ b/scripts/generate_schemas.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Generate JSON Schemas (draft 2020-12) for BVID-FE public data contracts.
+
+Currently emits:
+
+* ``docs/schemas/analysis_config.json`` — ``AnalysisConfig``
+* ``docs/schemas/analysis_results.json`` — ``AnalysisResults``
+
+The generator walks ``__dataclass_fields__`` and ``__annotations__`` of the
+target dataclasses and builds a JSON Schema document by hand. We deliberately
+avoid Pydantic v2 as a hard dependency (it's heavy and would compile a large
+C extension into the install path of every BVID-FE user). The conversion is
+deterministic so it can be diff-checked with ``--check``.
+
+Usage::
+
+    python scripts/generate_schemas.py            # write schemas
+    python scripts/generate_schemas.py --check    # fail if regen would diff
+
+The ``--check`` mode is intended for use in a future CI step; the issue
+explicitly asks us to expose the flag without wiring it into CI yet.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import sys
+import types
+import typing
+from pathlib import Path
+from typing import Any, Dict, List
+
+# We add ``src/`` to sys.path so the script can be run from a fresh clone
+# without first ``pip install -e .``.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+# Importing after sys.path tweak.
+from bvidfe.analysis.config import AnalysisConfig, MeshParams  # noqa: E402
+from bvidfe.analysis.results import AnalysisResults, FieldResults  # noqa: E402
+from bvidfe.core.geometry import ImpactorGeometry, PanelGeometry  # noqa: E402
+from bvidfe.core.material import OrthotropicMaterial  # noqa: E402
+from bvidfe.damage.state import DamageState, DelaminationEllipse  # noqa: E402
+from bvidfe.impact.mapping import ImpactEvent  # noqa: E402
+
+SCHEMA_DIR = REPO_ROOT / "docs" / "schemas"
+SCHEMA_URI = "https://json-schema.org/draft/2020-12/schema"
+SCHEMA_BASE = "https://ranipdx-glitch.github.io/BVID-FE/schemas/"
+
+
+# ---------------------------------------------------------------------------
+# Type -> JSON Schema conversion
+# ---------------------------------------------------------------------------
+
+
+def _is_optional(tp: Any) -> bool:
+    """``Optional[X]`` is ``Union[X, None]``; return True if NoneType is a member."""
+    origin = typing.get_origin(tp)
+    if origin in (typing.Union, types.UnionType):
+        return type(None) in typing.get_args(tp)
+    return False
+
+
+def _strip_optional(tp: Any) -> Any:
+    """Drop ``NoneType`` from a Union, leaving either a bare type or a Union."""
+    origin = typing.get_origin(tp)
+    if origin in (typing.Union, types.UnionType):
+        args = tuple(a for a in typing.get_args(tp) if a is not type(None))
+        if len(args) == 1:
+            return args[0]
+        return typing.Union[args]  # type: ignore[return-value]
+    return tp
+
+
+# Dataclasses we want to inline as ``$ref``s rather than re-emit at every use.
+_KNOWN_DATACLASSES: Dict[type, str] = {
+    PanelGeometry: "PanelGeometry",
+    ImpactorGeometry: "ImpactorGeometry",
+    ImpactEvent: "ImpactEvent",
+    DelaminationEllipse: "DelaminationEllipse",
+    DamageState: "DamageState",
+    MeshParams: "MeshParams",
+    FieldResults: "FieldResults",
+    OrthotropicMaterial: "OrthotropicMaterial",
+}
+
+
+def _type_to_schema(tp: Any, defs: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert a Python type annotation to a JSON Schema fragment.
+
+    ``defs`` is the ``$defs`` dict for the current top-level schema. Nested
+    dataclasses are emitted into ``defs`` on first encounter and referenced
+    via ``$ref`` thereafter.
+    """
+    # Optional[X] -> the inner X (we set ``required`` outside this helper).
+    if _is_optional(tp):
+        inner = _strip_optional(tp)
+        sub = _type_to_schema(inner, defs)
+        # Allow null as a valid value for optional fields.
+        if "type" in sub and isinstance(sub["type"], str):
+            sub = {"type": [sub["type"], "null"], **{k: v for k, v in sub.items() if k != "type"}}
+        else:
+            sub = {"anyOf": [sub, {"type": "null"}]}
+        return sub
+
+    origin = typing.get_origin(tp)
+
+    # Literal[...] -> enum
+    if origin is typing.Literal:
+        values = list(typing.get_args(tp))
+        # Infer JSON type from the first literal value.
+        sample = values[0]
+        if isinstance(sample, bool):
+            jt = "boolean"
+        elif isinstance(sample, int):
+            jt = "integer"
+        elif isinstance(sample, float):
+            jt = "number"
+        else:
+            jt = "string"
+        return {"type": jt, "enum": values}
+
+    # Union[X, Y] -> anyOf
+    if origin in (typing.Union, types.UnionType):
+        return {"anyOf": [_type_to_schema(a, defs) for a in typing.get_args(tp)]}
+
+    # list / List / Sequence / tuple
+    if origin in (list, typing.List, typing.Sequence, tuple, typing.Tuple):
+        args = typing.get_args(tp)
+        if not args:
+            return {"type": "array"}
+        if origin in (tuple, typing.Tuple) and len(args) > 1 and args[-1] is not Ellipsis:
+            # Fixed-length tuple -> prefixItems
+            return {
+                "type": "array",
+                "prefixItems": [_type_to_schema(a, defs) for a in args],
+                "minItems": len(args),
+                "maxItems": len(args),
+            }
+        return {"type": "array", "items": _type_to_schema(args[0], defs)}
+
+    # dict / Dict / Mapping
+    if origin in (dict, typing.Dict, typing.Mapping):
+        args = typing.get_args(tp)
+        if len(args) == 2:
+            return {"type": "object", "additionalProperties": _type_to_schema(args[1], defs)}
+        return {"type": "object"}
+
+    # Bare types and known dataclasses
+    if isinstance(tp, type):
+        if tp in _KNOWN_DATACLASSES:
+            name = _KNOWN_DATACLASSES[tp]
+            if name not in defs:
+                # Insert a placeholder so recursive types don't infinite-loop.
+                defs[name] = {}
+                defs[name] = _dataclass_schema_body(tp, defs)
+            return {"$ref": f"#/$defs/{name}"}
+        if tp is str:
+            return {"type": "string"}
+        if tp is bool:
+            return {"type": "boolean"}
+        if tp is int:
+            return {"type": "integer"}
+        if tp is float:
+            return {"type": "number"}
+        if tp is type(None):
+            return {"type": "null"}
+        # numpy arrays etc. — emit a permissive placeholder with a description.
+        try:
+            import numpy as np  # local import to avoid hard dependency at module load
+
+            if issubclass(tp, np.ndarray):
+                return {
+                    "type": "array",
+                    "description": f"numpy.ndarray ({tp.__name__}) — serialised as a nested list.",
+                }
+        except Exception:  # pragma: no cover - numpy is always installed in this repo
+            pass
+        # Fallback for unknown classes.
+        return {"description": f"Python type {tp.__name__} (no JSON Schema mapping)"}
+
+    # ForwardRef, TypeVar, etc. -> permissive placeholder.
+    return {"description": f"Unresolved annotation {tp!r}"}
+
+
+def _dataclass_schema_body(cls: type, defs: Dict[str, Any]) -> Dict[str, Any]:
+    """Build the JSON Schema *body* (without ``$schema`` / ``$id``) for a dataclass."""
+    hints = typing.get_type_hints(cls)
+    properties: Dict[str, Any] = {}
+    required: List[str] = []
+    for f in dataclasses.fields(cls):
+        ann = hints.get(f.name, f.type)
+        properties[f.name] = _type_to_schema(ann, defs)
+        # A field is required when it has no default AND no default_factory.
+        if (
+            f.default is dataclasses.MISSING
+            and f.default_factory is dataclasses.MISSING  # type: ignore[misc]
+        ):
+            required.append(f.name)
+    body: Dict[str, Any] = {
+        "type": "object",
+        "title": cls.__name__,
+        "description": (cls.__doc__ or "").strip().splitlines()[0] if cls.__doc__ else "",
+        "properties": properties,
+    }
+    if required:
+        body["required"] = required
+    body["additionalProperties"] = False
+    return body
+
+
+def dataclass_to_jsonschema(cls: type, schema_id: str) -> Dict[str, Any]:
+    """Top-level JSON Schema (draft 2020-12) for a dataclass."""
+    defs: Dict[str, Any] = {}
+    body = _dataclass_schema_body(cls, defs)
+    schema: Dict[str, Any] = {
+        "$schema": SCHEMA_URI,
+        "$id": schema_id,
+        **body,
+    }
+    if defs:
+        schema["$defs"] = dict(sorted(defs.items()))
+    return schema
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+TARGETS = [
+    (AnalysisConfig, SCHEMA_BASE + "analysis_config.json", "analysis_config.json"),
+    (AnalysisResults, SCHEMA_BASE + "analysis_results.json", "analysis_results.json"),
+]
+
+
+def _serialise(schema: Dict[str, Any]) -> str:
+    """Deterministic JSON encoding — sorted keys, 2-space indent, trailing newline."""
+    return json.dumps(schema, indent=2, sort_keys=True) + "\n"
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail with exit code 1 if regenerating would change any file on disk.",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=SCHEMA_DIR,
+        help=f"Destination directory (default: {SCHEMA_DIR.relative_to(REPO_ROOT)}).",
+    )
+    args = parser.parse_args(argv)
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    diffs: List[str] = []
+    for cls, schema_id, filename in TARGETS:
+        schema = dataclass_to_jsonschema(cls, schema_id)
+        rendered = _serialise(schema)
+        path = args.out_dir / filename
+        if args.check:
+            existing = path.read_text() if path.exists() else ""
+            if existing != rendered:
+                diffs.append(str(path.relative_to(REPO_ROOT)))
+        else:
+            path.write_text(rendered)
+            print(f"wrote {path.relative_to(REPO_ROOT)} ({len(rendered):,} bytes)")
+
+    if args.check:
+        if diffs:
+            print(
+                "generate_schemas.py --check: regeneration would change these files:",
+                file=sys.stderr,
+            )
+            for d in diffs:
+                print(f"  {d}", file=sys.stderr)
+            print(
+                "Run `python scripts/generate_schemas.py` to refresh them.",
+                file=sys.stderr,
+            )
+            return 1
+        print("generate_schemas.py --check: schemas are up to date.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #93.

## Summary

**MkDocs site**
- `mkdocs.yml` — Material theme; 6-section nav: Home, Quickstart, Python API, C-Scan Schema, Physics Models, Deployment. `exclude_docs` filters internal pages out of the published nav.
- New `docs/index.md`, `docs/quickstart.md` (points at `examples/quickstart.ipynb`), `docs/physics_models.md` (excerpts README's physics section), `docs/deployment.md` (summarises `DEPLOYMENT_STREAMLIT.md`).
- Existing `docs/python_api.md` and `docs/cscan_schema.md` reused as-is.

**GitHub Pages workflow**
- `.github/workflows/docs.yml` — triggers on **push to `main` only** (no PR builds). Uses OIDC + `actions/deploy-pages@v4`. **Pages must be enabled manually in repo settings** before the first deploy will succeed.

**JSON Schemas**
- `scripts/generate_schemas.py` — hand-rolled `dataclass_to_jsonschema(cls)` walking `__dataclass_fields__` + `typing.get_type_hints`. No Pydantic dependency (kept the install footprint light per the issue guardrail).
- Generates `docs/schemas/analysis_config.json` (7.6 KB) and `docs/schemas/analysis_results.json` (4.6 KB), both Draft 2020-12 and validated via `jsonschema.Draft202012Validator.check_schema`.
- Supports `python scripts/generate_schemas.py --check` for a future CI regeneration-gate (NOT wired into CI in this PR).

**Discoverability**
- `pyproject.toml`: new `[project.optional-dependencies].docs = ["mkdocs", "mkdocs-material"]` and `Documentation = "https://ranipdx-glitch.github.io/BVID-FE/"` in `[project.urls]`.
- `README.md`: Documentation badge + callout.
- `CITATION.cff`: `url:` now points to the GitHub Pages site.
- `.gitignore`: ignore local `site/` build output.

## Test plan
- [x] `mkdocs build --strict` — exit 0, zero warnings/errors
- [x] `python scripts/generate_schemas.py` and `--check` both clean and idempotent
- [x] `python -m pytest -x` → 373 passed
- [x] `black --check` + `ruff check` clean on touched files
- [ ] CI green
- [ ] After merge: enable GitHub Pages in repo settings (source: GitHub Actions) for the deploy to succeed

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTG1A1VE1zUzrF8TQM8Dxe)_