### PR TITLE
Reliability: guard `flexural_rigidity_Deff` sqrt against non-positive `D[0,0]`/`D[1,1]` (#107)

### DIFF
--- a/src/bvidfe/core/laminate.py
+++ b/src/bvidfe/core/laminate.py
@@ -378,7 +378,19 @@ class Laminate:
         float
             Effective bending stiffness D_eff (N*mm).
         """
-        return math.sqrt(self._D[0, 0] * self._D[1, 1])
+        # Guard against a non-positive or non-finite D11/D22 product: a degenerate
+        # bending matrix (e.g. from a pathological layup or corrupted _D) would
+        # otherwise yield NaN from math.sqrt of a negative number, or silently
+        # propagate a non-physical zero/Inf into downstream impact criteria.
+        D11 = float(self._D[0, 0])
+        D22 = float(self._D[1, 1])
+        if not (np.isfinite(D11) and np.isfinite(D22)) or D11 <= 0.0 or D22 <= 0.0:
+            raise ValueError(
+                f"flexural_rigidity_Deff requires positive bending stiffness; "
+                f"got D[0,0]={D11} and D[1,1]={D22}. Check layup / "
+                f"ply_thickness_mm consistency."
+            )
+        return math.sqrt(D11 * D22)
 
     # ------------------------------------------------------------------
     # Representation

--- a/tests/core/test_laminate.py
+++ b/tests/core/test_laminate.py
@@ -41,6 +41,39 @@ def test_D_eff_positive():
     assert lam.flexural_rigidity_Deff() > 0
 
 
+def test_flexural_rigidity_Deff_returns_positive_finite_float():
+    """Issue #107 regression: the new D[0,0]/D[1,1] positivity guard must NOT
+    false-trigger on a normal laminate."""
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    lam = Laminate(material=m, layup_deg=[0, 45, -45, 90] * 4, ply_thickness_mm=0.152)
+    D_eff = lam.flexural_rigidity_Deff()
+    assert isinstance(D_eff, float)
+    assert np.isfinite(D_eff)
+    assert D_eff > 0.0
+
+
+def test_flexural_rigidity_Deff_raises_on_zero_D():
+    """Issue #107: a degenerate bending matrix with non-positive D[0,0] or
+    D[1,1] must raise loudly rather than feeding a negative/zero into sqrt
+    and corrupting the Olsson impact threshold downstream."""
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    lam = Laminate(material=m, layup_deg=[0, 45, -45, 90] * 4, ply_thickness_mm=0.152)
+    # Corrupt the cached D so both diagonal terms are non-positive.
+    lam._D = np.zeros((3, 3), dtype=float)
+    with pytest.raises(ValueError, match=r"D\[0,0\].*D\[1,1\]"):
+        lam.flexural_rigidity_Deff()
+
+
+def test_flexural_rigidity_Deff_raises_on_negative_D11():
+    """Issue #107: even a single non-positive diagonal component must trip
+    the guard, with both field names surfaced in the error message."""
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    lam = Laminate(material=m, layup_deg=[0, 45, -45, 90] * 4, ply_thickness_mm=0.152)
+    lam._D[0, 0] = -1.0
+    with pytest.raises(ValueError, match=r"D\[0,0\].*D\[1,1\]"):
+        lam.flexural_rigidity_Deff()
+
+
 def test_effective_engineering_constants_valid_laminate_finite_positive():
     """Issue #21 regression: the new ill-conditioning guard must NOT
     false-trigger on a normal laminate."""


### PR DESCRIPTION
Closes #107.

## Summary
- Added a fail-fast guard in `Laminate.flexural_rigidity_Deff` (`src/bvidfe/core/laminate.py`) that raises `ValueError` if either `D[0,0]` or `D[1,1]` is non-positive or non-finite, before the `math.sqrt`. Style matches the existing guard in `Laminate.effective_engineering_constants`.
- New tests in `tests/core/test_laminate.py`: healthy laminate returns positive finite `D_eff`; zeroed `_D` raises with both field names in the message; a single negative `D[0,0]` also raises.
- Verified no pre-existing positivity invariant on `_D` elsewhere — the guard is not redundant.

Without this guard, an ill-conditioned laminate silently yields `nan` from `sqrt`, which propagates through Olsson onset, Soutis CAI, and ultimately into a fully-formed-looking knockdown / residual-strength JSON result.

## Test plan
- [x] `pytest -x` → 381 passed locally
- [x] `black src tests` and `ruff check` clean
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTG1A1VE1zUzrF8TQM8Dxe)_