### PR TITLE
Observability: compact `__repr__` for `DamageState`, `DelaminationEllipse`, `AnalysisResults` (#111)

### DIFF
--- a/src/bvidfe/analysis/results.py
+++ b/src/bvidfe/analysis/results.py
@@ -117,6 +117,16 @@ class AnalysisResults:
     #: structured tags for them are future work.
     warnings: List[str] = field(default_factory=list)
 
+    def __repr__(self) -> str:
+        return (
+            f"AnalysisResults(tier={self.tier_used!r}, "
+            f"kd={self.knockdown:.3f}, "
+            f"sigma={self.residual_strength_MPa:.1f}/"
+            f"{self.pristine_strength_MPa:.1f}MPa, "
+            f"dpa={self.dpa_mm2:.1f}mm2, "
+            f"notes={len(self.notes)}, warnings={len(self.warnings)})"
+        )
+
     def summary(self) -> str:
         lines = [
             "BVID Analysis Results",

--- a/src/bvidfe/damage/state.py
+++ b/src/bvidfe/damage/state.py
@@ -43,6 +43,13 @@ class DelaminationEllipse:
     def area_mm2(self) -> float:
         return math.pi * self.major_mm * self.minor_mm
 
+    def __repr__(self) -> str:
+        return (
+            f"DelaminationEllipse(iface={self.interface_index}, "
+            f"a={self.major_mm:.2g}mm, b={self.minor_mm:.2g}mm, "
+            f"theta={self.orientation_deg:.0f}deg)"
+        )
+
 
 @dataclass
 class DamageState:
@@ -67,3 +74,10 @@ class DamageState:
         for e in self.delaminations:
             out[e.interface_index] = out.get(e.interface_index, 0.0) + e.area_mm2
         return out
+
+    def __repr__(self) -> str:
+        return (
+            f"DamageState(n_delam={len(self.delaminations)}, "
+            f"dent={self.dent_depth_mm:.3g}mm, "
+            f"fbr={self.fiber_break_radius_mm:.3g}mm)"
+        )

--- a/tests/analysis/test_repr.py
+++ b/tests/analysis/test_repr.py
@@ -1,0 +1,97 @@
+"""Pin compact ``__repr__`` outputs for observability dataclasses.
+
+These tests use substring checks (not exact equality) so adding new fields
+to the dataclasses won't churn the assertions.
+"""
+
+from __future__ import annotations
+
+from bvidfe.analysis.results import AnalysisResults
+from bvidfe.damage.state import DamageState, DelaminationEllipse
+
+
+def test_delamination_ellipse_repr_is_compact() -> None:
+    e = DelaminationEllipse(
+        interface_index=3,
+        centroid_mm=(0.0, 0.0),
+        major_mm=12.5,
+        minor_mm=8.25,
+        orientation_deg=45.0,
+    )
+    r = repr(e)
+    assert r.startswith("DelaminationEllipse(")
+    assert r.endswith(")")
+    assert "iface=3" in r
+    # Compact numeric formatting (no full float spew).
+    assert "a=" in r and "mm" in r
+    assert "b=" in r
+    assert "theta=" in r
+    # Single line, short.
+    assert "\n" not in r
+    assert len(r) < 120
+
+
+def test_damage_state_repr_is_compact() -> None:
+    e1 = DelaminationEllipse(
+        interface_index=0,
+        centroid_mm=(0.0, 0.0),
+        major_mm=10.0,
+        minor_mm=5.0,
+        orientation_deg=0.0,
+    )
+    e2 = DelaminationEllipse(
+        interface_index=2,
+        centroid_mm=(1.0, 1.0),
+        major_mm=8.0,
+        minor_mm=4.0,
+        orientation_deg=30.0,
+    )
+    ds = DamageState(
+        delaminations=[e1, e2],
+        dent_depth_mm=0.512,
+        fiber_break_radius_mm=2.3,
+    )
+    r = repr(ds)
+    assert r.startswith("DamageState(")
+    assert r.endswith(")")
+    assert "n_delam=2" in r
+    assert "dent=" in r
+    assert "mm" in r
+    assert "\n" not in r
+    # Repr should NOT trigger expensive shapely union; just check it's short.
+    assert len(r) < 200
+
+
+def test_damage_state_repr_empty() -> None:
+    ds = DamageState()
+    r = repr(ds)
+    assert "n_delam=0" in r
+    assert "DamageState(" in r
+
+
+def test_analysis_results_repr_is_compact() -> None:
+    ds = DamageState(dent_depth_mm=0.3, fiber_break_radius_mm=0.0)
+    res = AnalysisResults(
+        residual_strength_MPa=412.7,
+        pristine_strength_MPa=625.5,
+        knockdown=0.6598,
+        damage=ds,
+        dpa_mm2=234.5,
+        tier_used="semi_analytical",
+        config_snapshot={},
+        notes=["something"],
+        warnings=[],
+    )
+    r = repr(res)
+    assert r.startswith("AnalysisResults(")
+    assert r.endswith(")")
+    assert "tier='semi_analytical'" in r
+    assert "kd=0.660" in r
+    # Residual / pristine sigma pair appears with MPa unit.
+    assert "MPa" in r
+    assert "412.7" in r
+    assert "625.5" in r
+    assert "notes=1" in r
+    assert "warnings=0" in r
+    assert "\n" not in r
+    assert len(r) < 200


### PR DESCRIPTION
Closes #111.

## Summary
Adds compact `__repr__` overrides on three key result/state classes so REPL/notebook debugging surfaces useful one-liners instead of walls of nested dataclass output.

- `DelaminationEllipse` (`src/bvidfe/damage/state.py`) → `DelaminationEllipse(iface=3, a=12mm, b=8.2mm, theta=45deg)`
- `DamageState` (`src/bvidfe/damage/state.py`) → `DamageState(n_delam=2, dent=0.512mm, fbr=2.3mm)`
- `AnalysisResults` (`src/bvidfe/analysis/results.py`) → `AnalysisResults(tier='semi_analytical', kd=0.660, sigma=412.7/625.5MPa, dpa=234.5mm2, notes=2, warnings=1)`

Tests in `tests/analysis/test_repr.py` (new) pin each repr via substring checks so future field additions don't churn the test.

## Implementation notes
- `DamageState.__repr__` deliberately uses the `fiber_break_radius_mm` field instead of the `projected_damage_area_mm2` property — the latter triggers a shapely union, which would be surprising and slow inside `repr`.
- `.summary()`, `to_dict()`, field definitions, and `bvidfe.__all__` are unchanged.
- No `rich` dependency — stdlib `__repr__` only.

## Test plan
- [x] `pytest -x` → 400 passed; 4 new repr tests pass
- [x] `black src tests` and `ruff check` clean
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTG1A1VE1zUzrF8TQM8Dxe)_