### PR TITLE
Physics: add Puck action-plane failure criterion to the registry (#113)

### DIFF
--- a/src/bvidfe/_types.py
+++ b/src/bvidfe/_types.py
@@ -29,7 +29,7 @@ LoadingMode = Literal["compression", "tension"]
 #: Failure-criterion name. ``failure/evaluator.py`` currently defines its own
 #: ``CriterionName`` alias; this duplicate exists so future callers can import
 #: from a single place once the evaluator is migrated in a follow-up PR.
-CriterionName = Literal["tsai_wu", "larc05"]
+CriterionName = Literal["tsai_wu", "larc05", "puck"]
 
 
 # ---------------------------------------------------------------------------
@@ -38,7 +38,7 @@ CriterionName = Literal["tsai_wu", "larc05"]
 
 _TIER_NAMES: frozenset[str] = frozenset({"empirical", "semi_analytical", "fe3d"})
 _LOADING_MODES: frozenset[str] = frozenset({"compression", "tension"})
-_CRITERION_NAMES: frozenset[str] = frozenset({"tsai_wu", "larc05"})
+_CRITERION_NAMES: frozenset[str] = frozenset({"tsai_wu", "larc05", "puck"})
 
 
 __all__ = [

--- a/src/bvidfe/core/material.py
+++ b/src/bvidfe/core/material.py
@@ -56,6 +56,12 @@ class OrthotropicMaterial:
     Zt: Optional[float] = None
     Zc: Optional[float] = None
     S13: Optional[float] = None
+    # Puck (1998) action-plane inclination parameters. Tension (``puck_p_nt_plus``)
+    # and compression (``puck_p_nt_minus``) slopes of the master fracture
+    # envelope at sigma_n = 0; conservative CFRP/epoxy defaults from
+    # Puck-Schürmann 1998 (Composites Sci. Tech. 58, 1045-1067).
+    puck_p_nt_plus: float = 0.30
+    puck_p_nt_minus: float = 0.25
 
     def __post_init__(self) -> None:
         positive_fields = (
@@ -82,6 +88,10 @@ class OrthotropicMaterial:
             v = getattr(self, k)
             if v is not None and v <= 0:
                 raise ValueError(f"{k} must be > 0 if provided (got {v})")
+        for k in ("puck_p_nt_plus", "puck_p_nt_minus"):
+            v = getattr(self, k)
+            if v < 0:
+                raise ValueError(f"{k} must be >= 0 (got {v})")
         if not -1.0 < self.nu12 < 0.5:
             raise ValueError(f"nu12 out of physical range (got {self.nu12})")
         # rho is kg/mm^3; realistic engineering materials span ~[1e-7, 1e-5]

--- a/src/bvidfe/failure/evaluator.py
+++ b/src/bvidfe/failure/evaluator.py
@@ -9,9 +9,10 @@ import numpy as np
 
 from bvidfe.core.material import OrthotropicMaterial
 from bvidfe.failure.larc05 import larc05_index, larc05_index_batch
+from bvidfe.failure.puck import puck_index, puck_index_batch
 from bvidfe.failure.tsai_wu import tsai_wu_index, tsai_wu_index_batch
 
-CriterionName = Literal["tsai_wu", "larc05"]
+CriterionName = Literal["tsai_wu", "larc05", "puck"]
 
 # Registry mapping criterion name → batch index function. New criteria are
 # added by extending this dict (and the ``CriterionName`` Literal) rather
@@ -21,6 +22,7 @@ _CRITERION_REGISTRY: dict[
 ] = {
     "tsai_wu": tsai_wu_index_batch,
     "larc05": larc05_index_batch,
+    "puck": puck_index_batch,
 }
 
 # Scalar variants used by ``FailureEvaluator._index`` (per-point evaluation).
@@ -30,6 +32,7 @@ _CRITERION_SCALAR_REGISTRY: dict[
 ] = {
     "tsai_wu": tsai_wu_index,
     "larc05": larc05_index,
+    "puck": puck_index,
 }
 
 

--- a/src/bvidfe/failure/puck.py
+++ b/src/bvidfe/failure/puck.py
@@ -1,0 +1,186 @@
+"""Puck (1998) action-plane composite failure criterion.
+
+Implements the inter-fiber-failure (IFF) action-plane search of Puck &
+Schürmann (Puck, A.; Schürmann, H., 1998, *Composites Science and
+Technology* 58, 1045-1067; refined in Puck & Knops, 2002 and the
+World-Wide Failure Exercise II). The fiber-failure (FF) mode is the
+simple maximum-stress envelope on sigma_1.
+
+For each candidate fracture-plane angle theta in [-90 deg, +90 deg], the
+out-of-plane stresses are transformed via the standard 2-3 plane
+rotation:
+
+    sigma_n  =  sigma_2 cos^2 theta + sigma_3 sin^2 theta + 2 tau_23 s c
+    tau_nt   = (sigma_3 - sigma_2) s c + tau_23 (c^2 - s^2)
+    tau_n1   =  tau_12 cos theta + tau_13 sin theta            (with s = sin t, c = cos t)
+
+The IFF index on that plane is
+
+    sigma_n >= 0   (tensile, Mode A):
+        f = sqrt( (tau_nt / R_A)^2 + (tau_n1 / S12)^2
+                 + (1 - p+ * Yt/R_A)^2 * (sigma_n/Yt)^2 )
+            + (p+ / R_A) * sigma_n
+
+    sigma_n < 0    (compressive, Mode B/C envelope):
+        f = sqrt( (tau_nt / R_A)^2 + (tau_n1 / S12)^2
+                 + (p- * sigma_n / R_A)^2 )
+            + (p- / R_A) * sigma_n
+
+where R_A = Yc / (2 (1 + p-)) is the transverse-transverse action-plane
+shear strength and p+/p- are the inclination parameters
+``mat.puck_p_nt_plus`` / ``mat.puck_p_nt_minus`` (Puck-Schürmann 1998,
+section 4; defaults p+ = 0.30, p- = 0.25 for CFRP/epoxy).
+
+The fiber index is
+
+    f_FF = sigma_1 / Xt  if sigma_1 >= 0 else |sigma_1| / Xc
+
+and the returned scalar is ``max(f_FF, max_theta f_IFF(theta))``.
+
+Voigt convention matches the rest of the codebase
+``[sigma_11, sigma_22, sigma_33, tau_23, tau_13, tau_12]``.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+from bvidfe.core.material import OrthotropicMaterial
+
+# Discrete sweep of candidate fracture-plane angles. 37 evenly-spaced
+# points in [-pi/2, +pi/2] gives 5 deg resolution, which is enough to
+# resolve the ~53 deg CFRP compression fracture plane within 1% of the
+# analytical index without sacrificing batch throughput.
+_N_THETA = 37
+_THETAS = np.linspace(-np.pi / 2.0, np.pi / 2.0, _N_THETA)
+_COS = np.cos(_THETAS)
+_SIN = np.sin(_THETAS)
+_C2 = _COS * _COS  # cos^2 theta
+_S2 = _SIN * _SIN  # sin^2 theta
+_SC = _SIN * _COS  # sin*cos
+_CS2 = _C2 - _S2  # cos^2 - sin^2 = cos(2 theta)
+
+
+def _action_plane_R_A(mat: OrthotropicMaterial) -> float:
+    """Transverse-transverse shear strength on the action plane (R_perp_perp_A).
+
+    Puck-Schürmann 1998 eq. (35): R_A = Yc / (2 (1 + p-)).
+    """
+    return mat.Yc / (2.0 * (1.0 + mat.puck_p_nt_minus))
+
+
+def puck_index(mat: OrthotropicMaterial, stress: Sequence[float]) -> float:
+    """Return the maximum Puck failure index for a Voigt-6 stress.
+
+    Performs the action-plane search across ``_N_THETA`` discrete angles
+    and returns ``max(fiber_index, max_theta(IFF_index))``. The IFF
+    index uses the standard Puck-Schürmann Mode-A (tensile sigma_n) and
+    Mode-B/C (compressive sigma_n) envelopes — see module docstring.
+
+    Parameters
+    ----------
+    mat : OrthotropicMaterial
+        Material card supplying Xt/Xc/Yt/Yc/S12 and the Puck inclination
+        parameters ``puck_p_nt_plus`` / ``puck_p_nt_minus``.
+    stress : sequence of 6 floats
+        Voigt-6 stress vector in the material frame, ordered
+        ``[sigma_1, sigma_2, sigma_3, tau_23, tau_13, tau_12]``.
+
+    Returns
+    -------
+    float
+        Dimensionless failure index. >= 1 means failure (fiber or IFF
+        mode, whichever governs).
+    """
+    s = np.asarray(stress, dtype=float)
+    if s.shape != (6,):
+        raise ValueError(f"stress must be shape (6,) (got {s.shape!r})")
+    # Re-use the batch routine with a singleton leading axis — the
+    # angular sweep is the costly part, the (1, 6) reshape is trivial.
+    return float(puck_index_batch(mat, s[None, :])[0])
+
+
+def puck_index_batch(mat: OrthotropicMaterial, stresses: np.ndarray) -> np.ndarray:
+    """Vectorised Puck failure index across a batch of Voigt-6 stresses.
+
+    For an input of shape ``(..., 6)``, returns shape ``stresses.shape[:-1]``.
+    Fully vectorised over both the batch axes and the angular sweep —
+    the inner action-plane search is a single np.einsum-free broadcast
+    so no Python-level loop runs.
+
+    Parameters
+    ----------
+    mat : OrthotropicMaterial
+        Material card; same fields as ``puck_index``.
+    stresses : np.ndarray
+        Shape ``(..., 6)`` array of Voigt-6 stress vectors.
+
+    Returns
+    -------
+    np.ndarray
+        Shape ``stresses.shape[:-1]``. Each entry is the maximum of the
+        fiber-mode index and the inter-fiber-mode index over the
+        ``_N_THETA`` candidate fracture planes.
+    """
+    s = np.asarray(stresses, dtype=float)
+    if s.shape[-1] != 6:
+        raise ValueError(f"stresses must have last axis 6 (got {s.shape!r})")
+    s1 = s[..., 0]
+    s2 = s[..., 1]
+    s3 = s[..., 2]
+    t23 = s[..., 3]
+    t13 = s[..., 4]
+    t12 = s[..., 5]
+
+    # ---- Fiber-failure (FF) max-stress envelope ----------------------------
+    # Tension uses Xt, compression uses Xc; np.where picks the right
+    # denominator element-wise.
+    Xden = np.where(s1 >= 0.0, mat.Xt, mat.Xc)
+    fiber_idx = np.abs(s1) / Xden
+
+    # ---- Inter-fiber-failure (IFF) action-plane sweep ----------------------
+    # Broadcast batch (..., ) against angle axis (n_theta,) by adding a
+    # trailing 1-axis to every batch stress component. Result shape is
+    # (..., n_theta).
+    s2_b = s2[..., None]
+    s3_b = s3[..., None]
+    t23_b = t23[..., None]
+    t13_b = t13[..., None]
+    t12_b = t12[..., None]
+
+    # Plane-rotation stresses on candidate fracture plane (2-3 rotation by theta).
+    sigma_n = s2_b * _C2 + s3_b * _S2 + 2.0 * t23_b * _SC
+    tau_nt = (s3_b - s2_b) * _SC + t23_b * _CS2
+    tau_n1 = t12_b * _COS + t13_b * _SIN
+
+    R_A = _action_plane_R_A(mat)
+    p_plus = mat.puck_p_nt_plus
+    p_minus = mat.puck_p_nt_minus
+    Yt = mat.Yt
+    S12 = mat.S12
+
+    # Tensile-sigma_n branch (Mode A).
+    # f_A = sqrt( (tau_nt/R_A)^2 + (tau_n1/S12)^2
+    #             + (1 - p+ Yt/R_A)^2 (sigma_n/Yt)^2 )
+    #       + (p+ / R_A) sigma_n
+    a_factor = 1.0 - p_plus * Yt / R_A
+    f_tensile = (
+        np.sqrt((tau_nt / R_A) ** 2 + (tau_n1 / S12) ** 2 + (a_factor * sigma_n / Yt) ** 2)
+        + (p_plus / R_A) * sigma_n
+    )
+
+    # Compressive-sigma_n branch (Mode B / C envelope).
+    # f_C = sqrt( (tau_nt/R_A)^2 + (tau_n1/S12)^2 + (p- sigma_n / R_A)^2 )
+    #       + (p- / R_A) sigma_n
+    f_compressive = (
+        np.sqrt((tau_nt / R_A) ** 2 + (tau_n1 / S12) ** 2 + (p_minus * sigma_n / R_A) ** 2)
+        + (p_minus / R_A) * sigma_n
+    )
+
+    iff_per_theta = np.where(sigma_n >= 0.0, f_tensile, f_compressive)
+    # Critical plane is the one that maximises the IFF index.
+    iff_idx = np.max(iff_per_theta, axis=-1)
+
+    return np.maximum(fiber_idx, iff_idx)

--- a/tests/failure/test_evaluator.py
+++ b/tests/failure/test_evaluator.py
@@ -46,7 +46,7 @@ def test_criterion_registry_contains_known_keys():
     has to update this test deliberately."""
     from bvidfe.failure.evaluator import _CRITERION_REGISTRY
 
-    assert set(_CRITERION_REGISTRY.keys()) == {"tsai_wu", "larc05"}
+    assert set(_CRITERION_REGISTRY.keys()) == {"tsai_wu", "larc05", "puck"}
 
 
 def test_evaluator_unknown_criterion_error_lists_valid_names():

--- a/tests/failure/test_puck.py
+++ b/tests/failure/test_puck.py
@@ -1,0 +1,137 @@
+"""Tests for the Puck (1998) action-plane failure criterion.
+
+Reference points are computed by hand from the Puck-Schürmann master
+fracture body. The three pinned cases are:
+
+  * Pure axial tension sigma_1 = X_t        -> fiber-mode index = 1.0
+  * Pure axial compression sigma_1 = -X_c   -> fiber-mode index = 1.0
+  * Pure transverse tension sigma_2 = Y_t   -> IFF Mode-A index = 1.0
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from bvidfe.core.material import MATERIAL_LIBRARY
+from bvidfe.failure.evaluator import (
+    _CRITERION_REGISTRY,
+    _CRITERION_SCALAR_REGISTRY,
+    FailureEvaluator,
+)
+from bvidfe.failure.puck import puck_index, puck_index_batch
+
+
+# ---------------------------------------------------------------------------
+# Registry wiring
+# ---------------------------------------------------------------------------
+
+
+def test_puck_in_batch_registry():
+    assert "puck" in _CRITERION_REGISTRY
+    assert _CRITERION_REGISTRY["puck"] is puck_index_batch
+
+
+def test_puck_in_scalar_registry():
+    assert "puck" in _CRITERION_SCALAR_REGISTRY
+    assert _CRITERION_SCALAR_REGISTRY["puck"] is puck_index
+
+
+def test_failure_evaluator_constructs_with_puck():
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    ev = FailureEvaluator(m, criterion="puck")
+    assert ev.criterion == "puck"
+    assert ev._evaluate_fn is puck_index_batch
+    assert ev._scalar_fn is puck_index
+
+
+# ---------------------------------------------------------------------------
+# Hand-computed reference points
+# ---------------------------------------------------------------------------
+
+
+def test_pure_axial_tension_at_Xt_is_one():
+    """sigma_1 = X_t, all other components zero -> fiber-mode index = 1.0."""
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    idx = puck_index(m, [m.Xt, 0.0, 0.0, 0.0, 0.0, 0.0])
+    assert idx == pytest.approx(1.0, abs=1e-9)
+
+
+def test_pure_axial_compression_at_minus_Xc_is_one():
+    """sigma_1 = -X_c, all other components zero -> fiber-mode index = 1.0."""
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    idx = puck_index(m, [-m.Xc, 0.0, 0.0, 0.0, 0.0, 0.0])
+    assert idx == pytest.approx(1.0, abs=1e-9)
+
+
+def test_pure_transverse_tension_at_Yt_is_one():
+    """sigma_2 = Y_t, all other components zero -> IFF Mode-A index = 1.0 on
+    the theta = 0 fracture plane (sigma_n = Y_t, tau_nt = tau_n1 = 0)."""
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    idx = puck_index(m, [0.0, m.Yt, 0.0, 0.0, 0.0, 0.0])
+    # theta = 0 lies exactly on the 37-point grid (centre sample), so the
+    # IFF index there is analytic-exact; no angular-resolution slop.
+    assert idx == pytest.approx(1.0, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Benign-state sanity check
+# ---------------------------------------------------------------------------
+
+
+def test_benign_stress_state_well_below_failure():
+    """A stress state at 10% of every strength loaded *one component at a
+    time* should yield a Puck index well below 0.2 — far from failure
+    for any criterion mode. (Loading every component simultaneously
+    sums under the square-root, so the SRSS-style envelope climbs faster
+    than a Tsai-Wu quadratic; pinning each component in isolation is
+    the cleaner sanity bound.)"""
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    for component_idx, scale in enumerate([m.Xt, m.Yt, m.Yt, m.S23, m.S12, m.S12]):
+        stress = [0.0] * 6
+        stress[component_idx] = 0.1 * scale
+        idx = puck_index(m, stress)
+        assert idx < 0.2, f"component {component_idx} gave index {idx}"
+
+
+# ---------------------------------------------------------------------------
+# Vectorised vs scalar equivalence
+# ---------------------------------------------------------------------------
+
+
+def test_puck_index_batch_matches_scalar():
+    """Numerical equivalence between puck_index_batch and the scalar
+    puck_index across a random batch — both walk the same 37-point
+    action-plane sweep."""
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    rng = np.random.default_rng(19)
+    stresses = rng.standard_normal((25, 6)) * 300.0
+    batch = puck_index_batch(m, stresses)
+    scalar = np.array([puck_index(m, s) for s in stresses])
+    np.testing.assert_allclose(batch, scalar, rtol=1e-12, atol=1e-9)
+
+
+def test_puck_index_batch_preserves_leading_axes():
+    """``puck_index_batch`` must accept ``(n, m, 6)`` and return ``(n, m)``
+    so ``FailureEvaluator.evaluate`` can pass its ``(n_elem, n_gp, 6)``
+    stress array unchanged."""
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    rng = np.random.default_rng(23)
+    stresses = rng.standard_normal((4, 8, 6)) * 100.0
+    assert puck_index_batch(m, stresses).shape == (4, 8)
+
+
+def test_puck_zero_stress_gives_zero():
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    assert puck_index(m, [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]) == 0.0
+
+
+def test_puck_via_evaluator():
+    """FailureEvaluator with criterion='puck' returns the same index as
+    direct puck_index calls — pins the dispatcher wiring."""
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    ev = FailureEvaluator(m, criterion="puck")
+    stress_field = np.array([[[0.0, m.Yt, 0.0, 0.0, 0.0, 0.0]]])
+    rpt = ev.evaluate(stress_field)
+    assert rpt.max_index == pytest.approx(1.0, abs=1e-9)
+    assert rpt.criterion == "puck"


### PR DESCRIPTION
Closes #113.

## Summary
Adds Puck's action-plane fracture criterion as a third option alongside Tsai-Wu and LaRC05.

**New module** `src/bvidfe/failure/puck.py`:
- `puck_index(stress, mat)` — scalar form for the FailureEvaluator scalar path.
- `puck_index_batch(stress, mat)` — vectorised over `(..., 6)` batch axis + a 37-point action-plane angle sweep over `[-π/2, +π/2]`. No Python loops.
- Fiber failure: max-stress on σ₁ against `X_t` / `X_c`.
- Inter-fibre failure: Mode-A for tensile σ_n, Mode-B/C for compressive σ_n, following Puck-Schürmann 1998 (cited in the docstring). `R_A = Yc / (2·(1+p⁻))` per their eq. (35).

**Wiring**:
- `OrthotropicMaterial` (`src/bvidfe/core/material.py`) gains two keyword-only fields with conservative CFRP defaults: `puck_p_nt_plus=0.30`, `puck_p_nt_minus=0.25`. Existing presets (AS4/3501-6, IM7/8552, T700/2510, T800/epoxy) construct unchanged.
- `CriterionName` Literal extended to `Literal["tsai_wu", "larc05", "puck"]` in both `src/bvidfe/_types.py` (canonical) and `src/bvidfe/failure/evaluator.py`.
- Both `_CRITERION_REGISTRY` and `_CRITERION_SCALAR_REGISTRY` (added in #84/#105) gain a `"puck"` entry — registry pattern paying off.

## Reference points (IM7/8552)

| Stress state | Puck index |
|---|---|
| σ₁ = +X_t (2560 MPa) | **1.000000** |
| σ₁ = -X_c (-1590 MPa) | **1.000000** |
| σ₂ = +Y_t (73 MPa) | **1.000000** |
| σ₂ = -Y_c (-185 MPa) | 0.9996 (analytical fracture plane ~50.77° doesn't fall on the 5°-spaced grid) |

## Test plan
- [x] 11 new Puck tests pass; full suite **407 passed, 0 failed**
- [x] Existing Tsai-Wu / LaRC05 tests unchanged and still pass
- [x] `black src tests` and `ruff check` clean
- [x] No new dependencies (numpy-only); no `pyproject.toml` changes
- [ ] CI green

## References
- Puck, A. and Schürmann, H. (1998). "Failure analysis of FRP laminates by means of physically based phenomenological models." *Composites Science and Technology* 58(7).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTG1A1VE1zUzrF8TQM8Dxe)_