### PR TITLE
API: consolidate `CriterionName` to canonical `_types.py` + wire `LoadingMode` (#82 follow-up)

### DIFF
--- a/src/bvidfe/_types.py
+++ b/src/bvidfe/_types.py
@@ -26,9 +26,10 @@ TierName = Literal["empirical", "semi_analytical", "fe3d"]
 #: In-plane loading mode selected on ``AnalysisConfig.loading``.
 LoadingMode = Literal["compression", "tension"]
 
-#: Failure-criterion name. ``failure/evaluator.py`` currently defines its own
-#: ``CriterionName`` alias; this duplicate exists so future callers can import
-#: from a single place once the evaluator is migrated in a follow-up PR.
+#: Failure-criterion name. Canonical source for the alias; ``failure/evaluator.py``
+#: and ``analysis/fe_tier.py`` import it from here. Extend this Literal (and the
+#: ``_CRITERION_NAMES`` validation set below) in lockstep with the registry in
+#: :mod:`bvidfe.failure.evaluator` when adding a new criterion.
 CriterionName = Literal["tsai_wu", "larc05", "puck"]
 
 

--- a/src/bvidfe/analysis/bvid.py
+++ b/src/bvidfe/analysis/bvid.py
@@ -7,13 +7,14 @@ from copy import deepcopy
 from dataclasses import asdict
 from typing import Union
 
+from bvidfe._types import LoadingMode
 from bvidfe.analysis.config import AnalysisConfig
-from bvidfe.analysis.results import AnalysisResults
 from bvidfe.analysis.fe_tier import (
     _fe3d_cai_first_ply_failure,
     fe3d_cai_buckling,
     fe3d_tai,
 )
+from bvidfe.analysis.results import AnalysisResults
 from bvidfe.analysis.semi_analytical import (
     SemiAnalyticalResult,
     semi_analytical_cai,
@@ -36,7 +37,7 @@ def _resolve_material(m: Union[str, OrthotropicMaterial]) -> OrthotropicMaterial
     return m
 
 
-def _pristine_strength(lam: Laminate, loading: str) -> float:
+def _pristine_strength(lam: Laminate, loading: LoadingMode) -> float:
     """Thickness-weighted ply-average pristine strength in the loading direction.
 
     For compression: sum_i t_i * (Xc*cos^2 + Yc*sin^2) / sum_i t_i

--- a/src/bvidfe/analysis/fe_tier.py
+++ b/src/bvidfe/analysis/fe_tier.py
@@ -14,12 +14,12 @@ from typing import List
 
 import numpy as np
 
+from bvidfe._types import CriterionName
 from bvidfe.analysis.config import AnalysisConfig
 from bvidfe.analysis.fe_mesh import FeMesh, build_fe_mesh, estimate_fe_mesh_size
 from bvidfe.core.laminate import Laminate
 from bvidfe.damage.state import DamageState
 from bvidfe.elements.hex8 import Hex8Element, build_geometry_table
-from bvidfe.failure.evaluator import CriterionName
 from bvidfe.failure.larc05 import larc05_index, larc05_index_batch
 from bvidfe.failure.tsai_wu import tsai_wu_index, tsai_wu_index_batch
 from bvidfe.solver.assembler import assemble_coo, assemble_global_stiffness

--- a/src/bvidfe/failure/evaluator.py
+++ b/src/bvidfe/failure/evaluator.py
@@ -3,20 +3,20 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Literal
+from typing import Callable
 
 import numpy as np
 
+from bvidfe._types import CriterionName
 from bvidfe.core.material import OrthotropicMaterial
 from bvidfe.failure.larc05 import larc05_index, larc05_index_batch
 from bvidfe.failure.puck import puck_index, puck_index_batch
 from bvidfe.failure.tsai_wu import tsai_wu_index, tsai_wu_index_batch
 
-CriterionName = Literal["tsai_wu", "larc05", "puck"]
-
 # Registry mapping criterion name → batch index function. New criteria are
-# added by extending this dict (and the ``CriterionName`` Literal) rather
-# than by adding another string-comparison branch in the evaluator.
+# added by extending this dict (and the ``CriterionName`` Literal in
+# :mod:`bvidfe._types`) rather than by adding another string-comparison
+# branch in the evaluator.
 _CRITERION_REGISTRY: dict[
     CriterionName, Callable[[OrthotropicMaterial, np.ndarray], np.ndarray]
 ] = {


### PR DESCRIPTION
Follow-up to #103 — closes the remainder of #82.

## Summary
- **`CriterionName` consolidation:** `src/bvidfe/failure/evaluator.py` had its own `CriterionName = Literal[...]` declaration alongside the canonical one in `src/bvidfe/_types.py`. The local copy is deleted; `evaluator.py` and `fe_tier.py` now import from `bvidfe._types`. One source of truth → adding the next criterion is one dict entry + one Literal extension in the canonical file.
- **Caller wiring:** `BvidAnalysis._pristine_strength(loading: str)` is re-annotated to `LoadingMode`. `_types.py` docstring updated to acknowledge it's now actually canonical.

## Test plan
- [x] `pytest -x` → 414 passed
- [x] `black --check` + `ruff check` clean on touched files
- [ ] CI green

(Pre-existing black drift in `tests/failure/test_puck.py` was confirmed present on `main` — out of scope for this PR; will be fixed in a separate small follow-up.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTG1A1VE1zUzrF8TQM8Dxe)_