### PR TITLE
Reliability: `Hex8iElement` logs a warning on singular `Kaa` + opt-in strict mode (#108)

### DIFF
--- a/src/bvidfe/elements/hex8i.py
+++ b/src/bvidfe/elements/hex8i.py
@@ -20,10 +20,24 @@ Condensation:
 
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 
 from bvidfe.elements.gauss import gauss_points_hex
 from bvidfe.elements.hex8 import Hex8Element, _validate_jacobian
+
+# Opt-in strict mode: when True, a singular Kaa during static condensation
+# raises LinAlgError instead of silently falling back to the un-condensed Kuu.
+# Default (False) preserves historical behavior; tests / callers may flip this
+# to fail fast when investigating mesh-quality issues.
+STRICT_HEX8I_CONDENSATION: bool = False
+
+_logger = logging.getLogger("bvidfe.elements")
+
+# Dedup key set so a large mesh doesn't spam the same warning per element.
+# Keys are (ply_angle_deg_rounded, cond_kaa_rounded).
+_warned_elements: set[tuple[float, float]] = set()
 
 
 class Hex8iElement(Hex8Element):
@@ -89,7 +103,45 @@ class Hex8iElement(Hex8Element):
         # Static condensation
         try:
             Kaa_inv = np.linalg.inv(Kaa)
-        except np.linalg.LinAlgError:
+        except np.linalg.LinAlgError as exc:
+            # Diagnostic: compute condition number of Kaa for the log/exception.
+            try:
+                cond_kaa = float(np.linalg.cond(Kaa))
+                if not np.isfinite(cond_kaa):
+                    cond_kaa = float("inf")
+            except (np.linalg.LinAlgError, ValueError):
+                cond_kaa = float("inf")
+
+            ply_angle = getattr(self, "ply_angle_deg", None)
+            elem_id = getattr(self, "element_id", None)
+            elem_label = (
+                f"hex8i element id={elem_id}" if elem_id is not None else "an hex8i element"
+            )
+
+            if STRICT_HEX8I_CONDENSATION:
+                raise np.linalg.LinAlgError(
+                    f"Singular Kaa during Hex8i static condensation "
+                    f"({elem_label}, ply_angle={ply_angle}, "
+                    f"cond(Kaa)={cond_kaa:.3e}); enrichment cannot be applied."
+                ) from exc
+
+            # Dedup so a 100k-element mesh doesn't emit 100k identical warnings.
+            ply_key = round(float(ply_angle), 3) if ply_angle is not None else float("nan")
+            if np.isfinite(cond_kaa):
+                cond_key = round(cond_kaa, -int(np.floor(np.log10(max(cond_kaa, 1.0)))))
+            else:
+                cond_key = float("inf")
+            dedup_key = (ply_key, cond_key)
+            if dedup_key not in _warned_elements:
+                _warned_elements.add(dedup_key)
+                _logger.warning(
+                    "Hex8i static condensation: Kaa is singular for %s "
+                    "(ply_angle=%s, cond(Kaa)=%.3e). Enrichment disabled for "
+                    "this element; check mesh quality if FE3D results are noisy.",
+                    elem_label,
+                    ply_angle,
+                    cond_kaa,
+                )
             return Kuu
         K = Kuu - Kua @ Kaa_inv @ Kua.T
         # Enforce exact symmetry

--- a/tests/elements/test_hex8i_kaa_singular.py
+++ b/tests/elements/test_hex8i_kaa_singular.py
@@ -1,0 +1,108 @@
+"""Regression tests for Hex8i behavior when Kaa is singular.
+
+Issue #108: previously the LinAlgError on `np.linalg.inv(Kaa)` was caught and
+silently swallowed, returning the un-condensed Kuu. We now emit a warning on
+the `bvidfe.elements` logger by default, and re-raise when
+`STRICT_HEX8I_CONDENSATION=True`.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import pytest
+
+from bvidfe.core.material import MATERIAL_LIBRARY
+from bvidfe.elements import hex8i as hex8i_module
+from bvidfe.elements.hex8i import Hex8iElement
+
+
+def _unit_cube_nodes() -> np.ndarray:
+    return np.array(
+        [
+            [0, 0, 0],
+            [1, 0, 0],
+            [1, 1, 0],
+            [0, 1, 0],
+            [0, 0, 1],
+            [1, 0, 1],
+            [1, 1, 1],
+            [0, 1, 1],
+        ],
+        dtype=float,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_warned_elements():
+    """Each test starts with a clean dedup set so warnings emit reliably."""
+    hex8i_module._warned_elements.clear()
+    yield
+    hex8i_module._warned_elements.clear()
+
+
+def _force_singular_kaa(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch np.linalg.inv in the hex8i module so only the Kaa (9x9) inversion fails.
+
+    The other np.linalg.inv calls in stiffness_matrix (e.g. J0_inv on a 3x3) must
+    still work. We detect Kaa by its (9, 9) shape.
+    """
+    real_inv = np.linalg.inv
+
+    def fake_inv(a, *args, **kwargs):
+        arr = np.asarray(a)
+        if arr.shape == (9, 9):
+            raise np.linalg.LinAlgError("forced singular Kaa for test")
+        return real_inv(a, *args, **kwargs)
+
+    monkeypatch.setattr(hex8i_module.np.linalg, "inv", fake_inv)
+
+
+def test_singular_kaa_default_mode_warns_and_returns_kuu(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    """Default mode: warning is emitted, stiffness is finite & well-shaped."""
+    _force_singular_kaa(monkeypatch)
+    # Make sure we're in default (non-strict) mode.
+    monkeypatch.setattr(hex8i_module, "STRICT_HEX8I_CONDENSATION", False)
+
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    elem = Hex8iElement(_unit_cube_nodes(), m, ply_angle_deg=0.0)
+
+    with caplog.at_level(logging.WARNING, logger="bvidfe.elements"):
+        K = elem.stiffness_matrix()
+
+    assert K.shape == (24, 24)
+    assert np.all(np.isfinite(K))
+    # K is Kuu (un-condensed) — still symmetric.
+    assert np.allclose(K, K.T, atol=1e-8)
+
+    # Warning must mention this is a Hex8i issue and surface a cond number.
+    warning_records = [
+        r for r in caplog.records if r.name == "bvidfe.elements" and r.levelno >= logging.WARNING
+    ]
+    assert warning_records, "expected a warning on bvidfe.elements logger"
+    msg = warning_records[0].getMessage()
+    assert "Hex8i" in msg
+    assert "Kaa" in msg
+    assert "cond(Kaa)" in msg
+
+
+def test_singular_kaa_strict_mode_raises(monkeypatch: pytest.MonkeyPatch):
+    """Strict mode: LinAlgError is re-raised with a chained cause."""
+    _force_singular_kaa(monkeypatch)
+    monkeypatch.setattr(hex8i_module, "STRICT_HEX8I_CONDENSATION", True)
+
+    m = MATERIAL_LIBRARY["IM7/8552"]
+    elem = Hex8iElement(_unit_cube_nodes(), m, ply_angle_deg=45.0)
+
+    with pytest.raises(np.linalg.LinAlgError) as excinfo:
+        elem.stiffness_matrix()
+
+    # Chained from original LinAlgError.
+    assert excinfo.value.__cause__ is not None
+    assert isinstance(excinfo.value.__cause__, np.linalg.LinAlgError)
+    # Message should reference Hex8i context.
+    assert "Hex8i" in str(excinfo.value)
+    assert "ply_angle=45.0" in str(excinfo.value)


### PR DESCRIPTION
Closes #108.

## Summary
`Hex8iElement` static condensation can hit a singular `Kaa` (degenerate elements, extreme aspect ratios, near-zero through-thickness modulus). The previous fallback silently returned the un-condensed `Kuu`, losing the entire incompatible-mode contribution that the element class exists to provide — invisible to the user, hard to diagnose, and possibly contributing to the FE3D non-convergence in #98.

Changes in `src/bvidfe/elements/hex8i.py`:
- New module-level constant `STRICT_HEX8I_CONDENSATION: bool = False`.
- In the `except LinAlgError` branch:
  - Compute a diagnostic `cond(Kaa)` (catches further numerical failure too — sets to `inf` if non-finite).
  - If `STRICT_HEX8I_CONDENSATION`: re-raise the original `LinAlgError` with chained context including ply angle and condition number.
  - Otherwise: emit `logging.getLogger("bvidfe.elements").warning(...)` with the diagnostic context. Module-level `_warned_elements` set dedupes per `(ply_angle, cond_kaa rounded)` so large meshes don't spam.
- Default behaviour preserved (fallback to un-condensed `Kuu`, no exception).

Sample warning text:
```
WARNING bvidfe.elements: Hex8i static condensation: Kaa is singular for an hex8i
element (ply_angle=30.0, cond(Kaa)=4.527e+01). Enrichment disabled for this
element; check mesh quality if FE3D results are noisy.
```

## Test plan
- [x] `tests/elements/test_hex8i_kaa_singular.py` (new) — 2 tests using a shape-targeted `np.linalg.inv` monkeypatch so only the `(9,9) Kaa` inversion fails. Cover default-fallback-emits-warning and `STRICT_*=True` re-raises.
- [x] Full suite: 416 passed (including 3 existing hex8i tests).
- [x] `black src tests` and `ruff check` clean
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTG1A1VE1zUzrF8TQM8Dxe)_