### PR TITLE
Streamlit: surface cache hit/miss + live sweep progress + failed-point summary (#112)

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,6 +17,7 @@ import io
 import json
 import math
 import sys
+import time
 import warnings
 from dataclasses import replace
 from datetime import date, datetime, timezone
@@ -1096,8 +1097,25 @@ if run_clicked:
                 st.stop()
         with st.spinner("Running BVID analysis…"):
             try:
+                # Time the cached call so we can surface cache-hit vs
+                # cache-miss as a subtle toast (#112). ``st.cache_data``
+                # returns its memoised payload without entering the wrapped
+                # function, so anything < ~50 ms is a hit in practice
+                # (a real BvidAnalysis solve is at least sub-second on the
+                # empirical tier and seconds-to-minutes on fe3d).
+                _t0 = time.perf_counter()
                 payload = _run_analysis_cached(config_dict)
+                _dt = time.perf_counter() - _t0
                 st.session_state["last_result"] = payload
+                try:
+                    if _dt < 0.05:
+                        st.toast("Cache hit — instant", icon="⚡")
+                    else:
+                        st.toast(f"Solved in {_dt:.1f}s", icon="✓")
+                except Exception:
+                    # ``st.toast`` is fairly new; never let UX sugar
+                    # block a successful analysis from rendering.
+                    pass
             except Exception as exc:
                 st.session_state["last_result"] = None
                 st.error(f"Analysis failed: {exc}")
@@ -1358,23 +1376,59 @@ with tabs[6]:
                         )
                         energies = []
             if energies:
+                # Live per-point progress (#112). The bar is wired into a
+                # callback passed to ``sweep_energies`` so each iteration
+                # updates the UI as it lands; ``progress_callback`` is
+                # ignored by ``st.cache_data``-style memoisation so we call
+                # the sweep entrypoint directly here. A buggy callback
+                # cannot abort the sweep itself — the library catches it.
+                prog = st.progress(0.0, text=f"0/{len(energies)} starting…")
+
+                def _on_point(i: int, total: int, inputs: dict) -> None:
+                    e_val = inputs.get("energy_J", "?")
+                    e_txt = f"{e_val:g}" if isinstance(e_val, (int, float)) else str(e_val)
+                    prog.progress(i / total, text=f"{i}/{total}: E={e_txt} J")
+
                 try:
                     with st.spinner(f"Running {len(energies)}-point {sweep_tier} sweep…"):
-                        df = _sweep_cached(config_dict, sweep_tier, tuple(energies))
+                        cfg_sweep = replace(_config_from_dict(config_dict), tier=sweep_tier)
+                        df = sweep_energies(
+                            cfg_sweep,
+                            list(energies),
+                            on_error="warn",
+                            progress_callback=_on_point,
+                        )
                 except Exception as exc:
                     st.error(f"Sweep failed: {exc}")
                 else:
+                    prog.empty()
+                    # Failed-point summary (#112). The fixed-schema sweep
+                    # DataFrame (#38) always carries an ``error`` column;
+                    # surface failed rows in a small table above the success
+                    # plot so the user sees which points to investigate.
+                    if "error" in df.columns:
+                        failed_df = df[df["error"].notna() & (df["error"] != "")]
+                    else:  # defensive — schema is fixed by parametric_sweep
+                        failed_df = df.loc[df["knockdown"].isna()]
                     if df["knockdown"].isna().all():
                         st.error(
                             "Every sweep point failed — check the sidebar "
                             "configuration and the energy values."
                         )
+                        if not failed_df.empty:
+                            st.dataframe(
+                                failed_df[["energy_J", "error"]],
+                                use_container_width=True,
+                            )
                     else:
-                        failed = df.loc[df["knockdown"].isna(), "energy_J"].tolist()
-                        if failed:
-                            st.warning(
-                                "Some sweep points failed and are blank: "
-                                + ", ".join(f"{e:g} J" for e in failed)
+                        if not failed_df.empty:
+                            st.warning(f"⚠ {len(failed_df)} point(s) failed:")
+                            cols_to_show = [
+                                c for c in ("energy_J", "error") if c in failed_df.columns
+                            ]
+                            st.dataframe(
+                                failed_df[cols_to_show],
+                                use_container_width=True,
                             )
                         _show_df(df)
                         ok = df.dropna(subset=["knockdown"])

--- a/src/bvidfe/sweep/parametric_sweep.py
+++ b/src/bvidfe/sweep/parametric_sweep.py
@@ -11,11 +11,19 @@ All three sweep entry points (`sweep_energies`, `sweep_layups`,
     results still reach the DataFrame and the CSV. ``"warn"`` is identical
     to ``"skip"`` but additionally emits a ``UserWarning`` per failure.
 
-  * ``progress_callback`` — optional ``Callable[[int, int], None]``
-    invoked as ``progress_callback(i_done, n_total)`` after each iteration
-    completes (success or failure). Used by the GUI ``SweepWorker`` to
-    drive its progress bar and by long-running scripts to report progress
-    to stderr / a logger.
+  * ``progress_callback`` — optional callable invoked once per iteration
+    to report progress. Two signatures are accepted (introspected at
+    runtime, so existing callers don't need to change):
+
+      - ``progress_callback(i_done, n_total)`` — legacy 2-arg form.
+      - ``progress_callback(i_done, n_total, inputs)`` — 3-arg form where
+        ``inputs`` is a small ``dict`` describing the iteration's swept
+        inputs (``energy_J``, ``layup``, or ``ply_thickness_mm``). Used by
+        the Streamlit UI to render a live ``E=…J`` progress label
+        (#112) and by the GUI ``SweepWorker`` to drive its progress bar.
+
+    Callback exceptions are caught and logged at DEBUG so a misbehaving
+    UI never aborts the sweep itself.
 
 Together these make sweeps robust to a single bad input (a degenerate
 mesh, a Tsai-Wu invalid combination, an out-of-range Olsson regime) and
@@ -25,19 +33,30 @@ aborted mid-run.
 
 from __future__ import annotations
 
+import inspect
+import logging
 import math
 import warnings
 from contextlib import contextmanager
 from dataclasses import replace
 from pathlib import Path
-from typing import Callable, Iterator, List, Optional, Sequence
+from typing import Any, Callable, Iterator, List, Optional, Sequence, Union
 
 import pandas as pd
 
 from bvidfe.analysis import AnalysisConfig, BvidAnalysis
 from bvidfe.impact.mapping import DPACapClipWarning, SmallMassQuasiStaticWarning
 
-_ProgressCallback = Callable[[int, int], None]
+logger = logging.getLogger(__name__)
+
+# Accept both 2-arg ``(i_done, n_total)`` and 3-arg
+# ``(i_done, n_total, inputs)`` progress callbacks — the latter (#112) carries
+# a small dict of the iteration's swept inputs so a UI can render a live
+# per-point label without re-implementing the loop.
+_ProgressCallback = Union[
+    Callable[[int, int], None],
+    Callable[[int, int, dict], None],
+]
 _ON_ERROR_VALUES = ("raise", "skip", "warn")
 
 
@@ -150,9 +169,48 @@ def _write_csv(df: pd.DataFrame, csv_path: Optional[Path]) -> None:
         df.to_csv(Path(csv_path), index=False)
 
 
-def _emit_progress(cb: Optional[_ProgressCallback], i: int, n: int) -> None:
-    if cb is not None:
-        cb(i, n)
+def _callback_accepts_inputs(cb: Callable[..., Any]) -> bool:
+    """Inspect ``cb`` to decide if it accepts the 3-arg ``(i, n, inputs)``
+    form. Falls back to the legacy 2-arg form on any introspection failure
+    (built-ins, C extensions, partials with unusual signatures, ...)."""
+    try:
+        params = inspect.signature(cb).parameters
+    except (TypeError, ValueError):
+        return False
+    # Count positional-capable params; *args is treated as accepting all.
+    positional = 0
+    for p in params.values():
+        if p.kind is inspect.Parameter.VAR_POSITIONAL:
+            return True
+        if p.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        ):
+            positional += 1
+    return positional >= 3
+
+
+def _emit_progress(
+    cb: Optional[_ProgressCallback],
+    i: int,
+    n: int,
+    inputs: Optional[dict] = None,
+) -> None:
+    """Invoke the progress callback, tolerating both 2-arg and 3-arg forms.
+
+    A buggy or slow callback (e.g. a Streamlit ``st.progress`` rendering
+    against a torn-down session) must never abort the sweep — exceptions
+    are swallowed at DEBUG.
+    """
+    if cb is None:
+        return
+    try:
+        if inputs is not None and _callback_accepts_inputs(cb):
+            cb(i, n, inputs)  # type: ignore[call-arg]
+        else:
+            cb(i, n)  # type: ignore[call-arg]
+    except Exception:  # noqa: BLE001 — callback errors must not sink the sweep
+        logger.debug("progress_callback raised; ignoring", exc_info=True)
 
 
 def sweep_energies(
@@ -181,7 +239,7 @@ def sweep_energies(
             row = _try_run_one(cfg, on_error, f"energy_J={float(E):g}")
             row["energy_J"] = float(E)
             rows.append(row)
-            _emit_progress(progress_callback, i + 1, n)
+            _emit_progress(progress_callback, i + 1, n, {"energy_J": float(E)})
     df = _finalize(rows, "energy_J")
     _write_csv(df, Path(csv_path) if csv_path else None)
     return df
@@ -205,7 +263,7 @@ def sweep_layups(
             row = _try_run_one(cfg, on_error, f"layup={layup_str}")
             row["layup"] = layup_str
             rows.append(row)
-            _emit_progress(progress_callback, i + 1, n)
+            _emit_progress(progress_callback, i + 1, n, {"layup": layup_str})
     df = _finalize(rows, "layup")
     _write_csv(df, Path(csv_path) if csv_path else None)
     return df
@@ -228,7 +286,7 @@ def sweep_thicknesses(
             row = _try_run_one(cfg, on_error, f"ply_thickness_mm={float(t):g}")
             row["ply_thickness_mm"] = float(t)
             rows.append(row)
-            _emit_progress(progress_callback, i + 1, n)
+            _emit_progress(progress_callback, i + 1, n, {"ply_thickness_mm": float(t)})
     df = _finalize(rows, "ply_thickness_mm")
     _write_csv(df, Path(csv_path) if csv_path else None)
     return df

--- a/tests/sweep/test_sweep.py
+++ b/tests/sweep/test_sweep.py
@@ -156,6 +156,65 @@ def test_sweep_energies_progress_callback_is_invoked():
     assert seen == [(1, 3), (2, 3), (3, 3)]
 
 
+def test_sweep_energies_progress_callback_three_arg_receives_inputs():
+    """Issue #112: the Streamlit UI passes a 3-arg callback so it can
+    render a live ``E=…J`` label. Existing 2-arg callbacks must keep
+    working (covered by ``..._progress_callback_is_invoked`` above) —
+    this test pins the 3-arg dispatch and the inputs-dict contract."""
+    cfg = _base_impact_cfg()
+    seen: list[tuple[int, int, dict]] = []
+    sweep_energies(
+        cfg,
+        energies_J=[5, 20],
+        progress_callback=lambda i, n, inp: seen.append((i, n, dict(inp))),
+    )
+    assert [(i, n) for i, n, _ in seen] == [(1, 2), (2, 2)]
+    assert seen[0][2] == {"energy_J": 5.0}
+    assert seen[1][2] == {"energy_J": 20.0}
+
+
+def test_sweep_progress_callback_exception_does_not_break_sweep():
+    """Issue #112: a buggy UI callback (e.g. a stale Streamlit handle on
+    a torn-down session) must not abort the whole sweep. The exception
+    is swallowed and logged at DEBUG; the DataFrame still finalises."""
+    cfg = _base_impact_cfg()
+    calls = {"n": 0}
+
+    def _bad_cb(i, n, inputs):
+        calls["n"] += 1
+        raise RuntimeError("UI callback exploded")
+
+    df = sweep_energies(cfg, energies_J=[5, 10], progress_callback=_bad_cb)
+    assert calls["n"] == 2
+    assert len(df) == 2
+    # Sweep itself succeeded — knockdowns are populated, error column NaN/empty.
+    assert df["knockdown"].notna().all()
+
+
+def test_sweep_layups_progress_callback_inputs_carries_layup():
+    """The 3-arg callback for ``sweep_layups`` carries the layup string."""
+    cfg = _base_impact_cfg()
+    seen: list[dict] = []
+    sweep_layups(
+        cfg,
+        layups=[[0, 90, 0, 90], [45, -45, 45, -45]],
+        progress_callback=lambda i, n, inp: seen.append(dict(inp)),
+    )
+    assert seen == [{"layup": "0/90/0/90"}, {"layup": "45/-45/45/-45"}]
+
+
+def test_sweep_thicknesses_progress_callback_inputs_carries_thickness():
+    """The 3-arg callback for ``sweep_thicknesses`` carries the thickness."""
+    cfg = _base_impact_cfg()
+    seen: list[dict] = []
+    sweep_thicknesses(
+        cfg,
+        ply_thicknesses_mm=[0.125, 0.200],
+        progress_callback=lambda i, n, inp: seen.append(dict(inp)),
+    )
+    assert seen == [{"ply_thickness_mm": 0.125}, {"ply_thickness_mm": 0.200}]
+
+
 def test_sweep_energies_rejects_unknown_on_error():
     cfg = _base_impact_cfg()
     import pytest


### PR DESCRIPTION
Closes #112.

## Summary

**Cache visibility (`app.py`)** — wrapped the cached analysis call with `time.perf_counter()`; emits `st.toast` with `"⚡ Cache hit — instant"` for sub-50 ms returns and `"✓ Solved in X.Xs"` for cache misses. Clear signal to the user that something happened — and how long it took.

**Live sweep progress (`app.py` + `src/bvidfe/sweep/parametric_sweep.py`)** — extended the existing `progress_callback` parameter to accept either the legacy 2-arg `(i, n)` signature or the new 3-arg `(i, n, inputs)` form (introspected at runtime via `inspect.signature`). The `inputs` dict carries the swept variable (`energy_J`, `layup`, `ply_thickness_mm`). The Streamlit sweep tab drives an `st.progress` bar with `f"{i}/{n}: E={inputs.get('energy_J', '?')}J"`. Bypasses `@st.cache_data` on the sweep so the callback actually fires. Callback exceptions are caught and logged at DEBUG via a module logger — a buggy UI can never sink a sweep.

**Failed-point summary** — on sweep completion, if the result DataFrame has an `error` column (from closed #38), failed rows are surfaced in a small `st.dataframe` above the success plot. If no errors, omitted.

## Test plan
- [x] New `tests/sweep/test_sweep.py` cases: 3-arg dispatch + inputs contract for all three sweep entrypoints, exception tolerance
- [x] `streamlit run app.py --server.headless true --server.port 8501` boots clean; `/_stcore/health` returns `ok`; no exceptions in server log
- [x] `pytest -x` → 418 passed; existing `test_streamlit_app.py` smoke test still passes
- [x] `black src tests app.py` and `ruff check src tests app.py` clean
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTG1A1VE1zUzrF8TQM8Dxe)_