### PR TITLE
Release: publish to PyPI via OIDC Trusted Publishing on `v*` tags + cut 0.2.0 (#116)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish to PyPI
+on:
+  push:
+    tags: ['v*']
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Verify tag matches pyproject version
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          VER=$(python -c "import tomllib; print(tomllib.loads(open('pyproject.toml','rb').read().decode())['project']['version'])")
+          if [ "$TAG" != "$VER" ]; then
+            echo "::error::tag ($TAG) != pyproject.toml version ($VER)"; exit 1
+          fi
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip build twine
+      - name: Build sdist + wheel
+        run: python -m build
+      - name: Twine check
+        run: python -m twine check dist/*
+      - name: Publish to PyPI via OIDC
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,18 @@
 
 All notable changes to BVID-FE are documented in this file.
 
-## [0.2.0-dev] - unreleased
+## [Unreleased]
 
-In-progress work toward v0.2.0. No tag yet.
+## [0.2.0] - 2026-05-21
+
+First tagged release after `0.1.0`. Major themes: a fully wired 3-D
+hex-element FE tier (`fe3d`) with eigenvalue buckling and FPF coupons,
+per-ply thickness throughout the stack, a Streamlit GUI, validated
+public datasets exercised in CI, a `SemiAnalyticalResult` dataclass on
+the semi-analytical path, vectorised LaRC05/Tsai-Wu failure-criterion
+batches, refreshed README/ARCHITECTURE docs, and the OIDC Trusted
+Publishing workflow that produced this release (issue #116). See the
+detailed entries below.
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,48 @@ any drift. It is informational only (always exits 0) and prevents agents from
 delegating commits while formatting is broken. If `black`/`ruff` are not
 installed yet, the hook prints a friendly note and exits cleanly.
 
+## Releasing
+
+BVID-FE publishes to PyPI via **OIDC Trusted Publishing** — there is no
+long-lived API token stored in the repo. The release flow is driven by
+`.github/workflows/publish.yml`, which triggers on any tag matching `v*`.
+
+### One-time PyPI setup (maintainer only)
+
+Trusted Publishing must be configured **once** on PyPI for this repo. See
+[PyPI's Trusted Publishing docs](https://docs.pypi.org/trusted-publishers/)
+for the canonical instructions. Register a pending or existing publisher
+with:
+
+- **Repository owner:** `ranipdx-glitch`
+- **Repository name:** `BVID-FE`
+- **Workflow filename:** `publish.yml`
+- **Environment name:** `release`
+
+A matching GitHub Actions environment named `release` must also exist on
+the repo (Settings → Environments → New environment → `release`). The
+workflow declares `environment: release`, so it will queue indefinitely
+until that environment is created — which is the intended fail-safe.
+
+### Cut-a-release flow
+
+1. Bump `[project].version` in `pyproject.toml` (e.g. `0.2.0` →
+   `0.2.1` for a patch, `0.3.0` for a feature release).
+2. Update `CHANGELOG.md`: move the `## [Unreleased]` notes into a
+   new `## [X.Y.Z] - YYYY-MM-DD` section (today's date) and leave a
+   fresh empty `## [Unreleased]` above it.
+3. Commit those two changes on `main`.
+4. Tag the commit with `git tag vX.Y.Z` (note the leading `v`) and
+   push with `git push origin vX.Y.Z`.
+5. The `Publish to PyPI` workflow takes over: it verifies the tag
+   matches `pyproject.toml`, builds an sdist + wheel, runs
+   `twine check`, and uploads to PyPI through OIDC. No manual token
+   handling.
+
+If the tag/version check fails, delete the tag (`git push --delete
+origin vX.Y.Z` and `git tag -d vX.Y.Z`), fix the version mismatch,
+and re-tag.
+
 ## Code of Conduct
 
 Be respectful. Focus feedback on code and ideas, not people. Contributions at any experience level are welcome.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bvidfe"
-version = "0.2.0.dev0"
+version = "0.2.0"
 description = "Barely Visible Impact Damage residual-strength analysis for composite laminates"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Closes #116.

## Summary

**New workflow** `.github/workflows/publish.yml` — triggers on `v*` tags, publishes to PyPI via OIDC Trusted Publishing. No API token stored as a GitHub secret.

Pipeline:
1. `actions/checkout@v6`
2. `actions/setup-python@v6` (3.12)
3. Verify that the tag (without the leading `v`) matches `[project].version` in `pyproject.toml`. If they disagree, fail the run before building.
4. Upgrade `pip`, install `build` + `twine`.
5. `python -m build` (sdist + wheel).
6. `python -m twine check dist/*` (metadata sanity).
7. `pypa/gh-action-pypi-publish@release/v1` with OIDC (`permissions: id-token: write`, `environment: release`).

**Version bump** — `pyproject.toml` `version` field `0.2.0.dev0` → `0.2.0`. Nothing else in `pyproject.toml` touched.

**CHANGELOG** — the existing `[0.2.0-dev] - unreleased` block becomes `[0.2.0] - 2026-05-21` with a release summary; a fresh empty `## [Unreleased]` is inserted above it. Historical entries preserved verbatim.

**CONTRIBUTING.md** — new `## Releasing` section documenting:
- One-time PyPI Trusted Publishing setup (repo `ranipdx-glitch/BVID-FE`, environment `release`)
- Cut-a-release flow: bump version → update CHANGELOG → tag `vX.Y.Z` → push tag → workflow handles the rest

## Local validation
- `python -m build` succeeds; artifacts `bvidfe-0.2.0.tar.gz` + `bvidfe-0.2.0-py3-none-any.whl` produced (and deleted before commit).
- `python -m twine check dist/*` PASSED.
- `pytest -x` → 414 passed.

## Maintainer follow-up (one-time, before first release)
- [ ] Enable PyPI Trusted Publishing for this repo + `release` environment ([docs](https://docs.pypi.org/trusted-publishers/))
- [ ] Create the `release` GitHub environment in repo settings
- After those are done, tag `v0.2.0` → `git push origin v0.2.0` → workflow does the rest.

## Test plan
- [x] Local build + twine check pass
- [x] `pytest -x` → 414 passed
- [x] `black --check` + `ruff check` clean on touched files
- [ ] CI green (the publish workflow won't run on this PR — only on tag pushes)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTG1A1VE1zUzrF8TQM8Dxe)_