### PR TITLE
style: black-format tests/failure/test_puck.py

### DIFF
--- a/tests/failure/test_puck.py
+++ b/tests/failure/test_puck.py
@@ -21,7 +21,6 @@ from bvidfe.failure.evaluator import (
 )
 from bvidfe.failure.puck import puck_index, puck_index_batch
 
-
 # ---------------------------------------------------------------------------
 # Registry wiring
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Removes one extraneous blank line in `tests/failure/test_puck.py` that `black --check` flags. The file was added in PR #121; the contributing agent's local black produced slightly different output. This aligns it with the version pinned in dev deps so the SessionStart hook and any future `black --check` stays clean.

Three subsequent implementation agents in #82-follow-up / #108 / #116 confirmed the drift was pre-existing and stayed in scope. This is the housekeeping follow-up.

Trivial 1-line removal, no functional change.

## Test plan
- [x] `black --check tests/failure/test_puck.py` → clean
- [x] Existing Puck criterion tests still pass (no logic changed)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTG1A1VE1zUzrF8TQM8Dxe)_